### PR TITLE
Add docker compose setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "RSS-TTS Development",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "web",
+  "runServices": ["web", "worker", "redis", "db"],
   "workspaceFolder": "/app",
   "forwardPorts": [8000],
   "customizations": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ docker-compose logs -f
 
 # Stop all services
 docker-compose down
+
+# For production
+docker-compose -f docker-compose.prod.yml up -d
 ```
 
 ### GitHub Codespaces

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,35 @@
+version: "3.9"
+
+services:
+  web:
+    build: .
+    command: gunicorn rss_tts.wsgi:application --bind 0.0.0.0:8000
+    env_file: .env
+    depends_on:
+      - db
+      - redis
+    ports:
+      - "8000:8000"
+
+  worker:
+    build: .
+    command: celery -A rss_tts worker --loglevel=info
+    env_file: .env
+    depends_on:
+      - redis
+      - db
+
+  redis:
+    image: redis:7
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: rss_tts
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "3.9"
+
+services:
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    environment:
+      DJANGO_SECRET_KEY: dev-secret-key
+      DJANGO_DEBUG: "True"
+      POSTGRES_DB: rss_tts
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+    depends_on:
+      - db
+      - redis
+
+  worker:
+    build: .
+    command: celery -A rss_tts worker --loglevel=info
+    volumes:
+      - .:/app
+    environment:
+      DJANGO_SECRET_KEY: dev-secret-key
+      DJANGO_DEBUG: "True"
+      POSTGRES_DB: rss_tts
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+      CELERY_BROKER_URL: redis://redis:6379/0
+    depends_on:
+      - db
+      - redis
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: rss_tts
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Django>=5.0,<6.0
 djangorestframework>=3.14,<4.0
+celery>=5.3,<6.0
+psycopg[binary]>=3.1,<4.0

--- a/rss_tts/__init__.py
+++ b/rss_tts/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ["celery_app"]

--- a/rss_tts/celery.py
+++ b/rss_tts/celery.py
@@ -1,0 +1,8 @@
+import os
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "rss_tts.settings")
+
+app = Celery("rss_tts")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()

--- a/rss_tts/settings.py
+++ b/rss_tts/settings.py
@@ -62,12 +62,26 @@ WSGI_APPLICATION = "rss_tts.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+if os.environ.get("POSTGRES_DB"):
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.environ.get("POSTGRES_DB", "rss_tts"),
+            "USER": os.environ.get("POSTGRES_USER", "postgres"),
+            "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "postgres"),
+            "HOST": os.environ.get("POSTGRES_HOST", "db"),
+            "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+        }
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }
+
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://redis:6379/0")
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -9,6 +9,17 @@ class TestProjectStructure(unittest.TestCase):
     def test_settings_exists(self):
         self.assertTrue(os.path.isfile(os.path.join("rss_tts", "settings.py")))
 
+    def test_docker_compose_exists(self):
+        self.assertTrue(os.path.isfile("docker-compose.yml"))
+
+    def test_devcontainer_updated(self):
+        import json
+
+        with open(os.path.join(".devcontainer", "devcontainer.json")) as f:
+            data = json.load(f)
+
+        self.assertIn("runServices", data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add Dockerfile for Django/Celery image
- define dev docker-compose with web, worker, redis, and Postgres
- add production docker compose file
- configure Celery and Postgres in Django settings
- update devcontainer to start all services
- update README with production compose instructions
- add tests for new docker setup

## Testing
- `python -m unittest discover -s tests`