### PR TITLE
Clarify code style guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pre-commit install
 
 ### Coding Standards
 
-We follow [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide for Python code. See [CODING_STANDARDS.md](CODING_STANDARDS.md) for our complete coding guidelines.
+We follow the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide for Python code. All classes, methods and functions should include docstrings using the [Google Python style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings). See [CODING_STANDARDS.md](CODING_STANDARDS.md) for our complete coding guidelines.
 
 ### Branching Strategy
 


### PR DESCRIPTION
### **User description**
## Summary
- add docstring style note to coding standards section

## Testing
- `python -m unittest discover -s tests`


___

### **PR Type**
Documentation


___

### **Description**
- Add docstring requirement in README coding standards

- Specify Google Python style for docstrings

- Clarify PEP8 reference for Python code


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Require Google-style docstrings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Added docstring requirement for classes, methods, and functions<br> <li> Specified use of Google Python style for docstrings<br> <li> Retained PEP 8 reference and CODING_STANDARDS.md link


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/21/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>