### PR TITLE
Include redis server in application containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "RSS-TTS Development",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "web",
-  "runServices": ["web", "worker", "redis"],
+  "runServices": ["web", "worker"],
   "workspaceFolder": "/app",
   "forwardPorts": [8000],
   "customizations": {

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ POSTGRES_HOST=db
 POSTGRES_PORT=5432
 
 # Celery settings
-CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_BROKER_URL=redis://worker:6379/0
 
 # API keys
 OPENAI_API_KEY=your-openai-api-key-here

--- a/.env.sample
+++ b/.env.sample
@@ -15,7 +15,7 @@ POSTGRES_HOST=db
 POSTGRES_PORT=5432
 
 # Celery configuration
-CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_BROKER_URL=redis://worker:6379/0
 
 # OpenAI settings
 OPENAI_API_KEY=your-openai-key-here

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,17 @@ WORKDIR /app
 
 # Install dependencies
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends redis-server \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
 
 # Copy project files
 COPY . .
+RUN chmod +x /app/start-with-redis.sh
 
 # Expose port for Django
 EXPOSE 8000
 
-# Default command to run the Django development server
+ENTRYPOINT ["/app/start-with-redis.sh"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ cp .env.example .env
 docker-compose -f docker-compose.prod.yml up -d
 ```
 
+Redis runs inside the worker container. Its data lives in `/data/redis` which is
+mapped to the named volume `redis-data`. If you want to persist Redis data on
+your host machine, replace that volume mapping with a bind mount:
+
+```yaml
+services:
+  worker:
+    volumes:
+      - ./redis-data:/data/redis
+```
+
+
 ### Environment Configuration
 
 Copy `.env.sample` to `.env` and update the values with your local secrets:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,13 +5,13 @@ services:
     build: .
     command: gunicorn rss_tts.wsgi:application --bind 0.0.0.0:8000
     env_file: .env
-    depends_on:
-      redis:
-        condition: service_healthy
+    environment:
+      CELERY_BROKER_URL: redis://worker:6379/0
     ports:
       - "8000:8000"
     volumes:
       - sqlite-data:/app/data
+      - redis-data:/data/redis
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health/"]
       interval: 30s
@@ -23,11 +23,11 @@ services:
     build: .
     command: celery -A rss_tts worker --loglevel=info
     env_file: .env
-    depends_on:
-      redis:
-        condition: service_healthy
+    environment:
+      CELERY_BROKER_URL: redis://localhost:6379/0
     volumes:
       - sqlite-data:/app/data
+      - redis-data:/data/redis
     healthcheck:
       test: ["CMD", "celery", "-A", "rss_tts", "inspect", "ping"]
       interval: 30s
@@ -35,13 +35,9 @@ services:
       retries: 3
       start_period: 20s
 
-  redis:
-    image: redis:7
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 5s
-      retries: 3
+    ports:
+      - "6379:6379"
 
 volumes:
   sqlite-data:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,15 @@ services:
     volumes:
       - .:/app
       - sqlite-data:/app/data
+      - redis-data:/data/redis
     ports:
       - "8000:8000"
     environment:
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-dev-secret-key}
       DJANGO_DEBUG: "True"
+      CELERY_BROKER_URL: redis://worker:6379/0
     depends_on:
-      - redis
+      - worker
 
   worker:
     build: .
@@ -21,17 +23,14 @@ services:
     volumes:
       - .:/app
       - sqlite-data:/app/data
+      - redis-data:/data/redis
     environment:
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-dev-secret-key}
       DJANGO_DEBUG: "True"
-      CELERY_BROKER_URL: redis://redis:6379/0
-    depends_on:
-      - redis
-
-  redis:
-    image: redis:7
+      CELERY_BROKER_URL: redis://localhost:6379/0
     ports:
       - "6379:6379"
 
 volumes:
   sqlite-data:
+  redis-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Django>=5.0,<6.0
 djangorestframework>=3.14,<4.0
 celery>=5.3,<6.0
+redis>=5.0,<6.0
+PyYAML>=6.0,<7.0
 gunicorn>=21.2,<24.0

--- a/rss_tts/settings.py
+++ b/rss_tts/settings.py
@@ -95,7 +95,7 @@ else:
         }
     }
 
-CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://redis:6379/0")
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators

--- a/start-with-redis.sh
+++ b/start-with-redis.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+REDIS_DATA_DIR="${REDIS_DATA_DIR:-/data/redis}"
+mkdir -p "$REDIS_DATA_DIR"
+redis-server --daemonize yes --dir "$REDIS_DATA_DIR"
+exec "$@"

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -37,6 +37,14 @@ class TestDockerfile(unittest.TestCase):
             content = f.read()
         self.assertIn("celery", content.lower(), "Dockerfile should install Celery")
 
+    def test_install_redis(self):
+        """Verify redis-server is installed in the Dockerfile."""
+        if not os.path.isfile(self.dockerfile_path):
+            self.skipTest("Dockerfile missing")
+        with open(self.dockerfile_path, "r", encoding="utf-8") as f:
+            content = f.read().lower()
+        self.assertIn("redis-server", content, "Dockerfile should install redis-server")
+
     def test_expose_port(self):
         """Verify port 8000 is exposed in the Dockerfile."""
         if not os.path.isfile(self.dockerfile_path):

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -30,12 +30,15 @@ class TestDockerfile(unittest.TestCase):
         )
 
     def test_install_celery(self):
-        """Verify Celery is installed in the Dockerfile."""
-        if not os.path.isfile(self.dockerfile_path):
-            self.skipTest("Dockerfile missing")
-        with open(self.dockerfile_path, "r", encoding="utf-8") as f:
+        """Verify Celery is installed in the requirements.txt file."""
+        requirements_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "requirements.txt"
+        )
+        if not os.path.isfile(requirements_path):
+            self.skipTest("requirements.txt missing")
+        with open(requirements_path, "r", encoding="utf-8") as f:
             content = f.read()
-        self.assertIn("celery", content.lower(), "Dockerfile should install Celery")
+        self.assertIn("celery", content.lower(), "requirements.txt should include Celery")
 
     def test_install_redis(self):
         """Verify redis-server is installed in the Dockerfile."""

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -50,8 +50,10 @@ class TestProjectStructure(unittest.TestCase):
         """Ensure docker-compose.yml does not define an external redis service."""
         with open("docker-compose.yml", "r", encoding="utf-8") as f:
             compose_content = f.read()
-
-        self.assertNotIn("redis:", compose_content)
+            
+        import yaml
+        compose_data = yaml.safe_load(compose_content)
+        self.assertNotIn("redis", compose_data.get("services", {}))
 
 
 if __name__ == "__main__":

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -42,8 +42,16 @@ class TestProjectStructure(unittest.TestCase):
             data = json.load(f)
 
         self.assertIn("runServices", data)
-        # Ensure db service is not required in services list
-        self.assertIn("redis", data["runServices"])
+        # Redis should now run inside a service container, so it is not a
+        # separate service in runServices
+        self.assertNotIn("redis", data["runServices"])
+
+    def test_docker_compose_has_no_redis_service(self):
+        """Ensure docker-compose.yml does not define an external redis service."""
+        with open("docker-compose.yml", "r", encoding="utf-8") as f:
+            compose_content = f.read()
+
+        self.assertNotIn("redis:", compose_content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- bake redis-server into the base Docker image and start it in the background
- update docker compose files to use the built‑in redis instance
- adjust devcontainer configuration
- set default `CELERY_BROKER_URL` to localhost
- document redis persistence options
- update sample env files
- add tests for redis configuration

## Testing
- `pre-commit` *(fails: command not found)*
- `python -m unittest discover -s tests` *(fails: ImportError: Celery not found, redis test fails)*