### PR TITLE
Add bootstrap base template and home view

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 # Install dependencies
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
+# Install Celery (pulled from requirements.txt)
 
 # Copy project files
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 # Install dependencies
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-# Install Celery (pulled from requirements.txt)
+# Celery is included in requirements.txt and installed above
 
 # Copy project files
 COPY . .

--- a/rss_tts/urls.py
+++ b/rss_tts/urls.py
@@ -3,6 +3,9 @@
 from django.contrib import admin
 from django.urls import path
 
+from text_to_audio.views import HomeView
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", HomeView.as_view(), name="home"),
 ]

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,25 @@
+import os
+from django.conf import settings
+from django.test import Client, TestCase
+
+
+class TestFrontendTemplates(TestCase):
+    """Tests for basic frontend templates and views."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def _template_path(self, relative):
+        return os.path.join(settings.BASE_DIR, "text_to_audio", "templates", *relative.split("/"))
+
+    def test_base_template_exists(self):
+        self.assertTrue(os.path.isfile(self._template_path("base.html")), "base.html not found")
+
+    def test_partial_templates_exist(self):
+        for name in ("partials/_nav.html", "partials/_header.html", "partials/_footer.html"):
+            self.assertTrue(os.path.isfile(self._template_path(name)), f"{name} not found")
+
+    def test_home_view_renders(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "index.html")

--- a/text_to_audio/templates/base.html
+++ b/text_to_audio/templates/base.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}RSS-TTS{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    {% include 'partials/_nav.html' %}
+    {% include 'partials/_header.html' %}
+    <main class="container mt-4">
+      {% block content %}{% endblock %}
+    </main>
+    {% include 'partials/_footer.html' %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>

--- a/text_to_audio/templates/index.html
+++ b/text_to_audio/templates/index.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+
+{% block title %}Home - RSS-TTS{% endblock %}
+
+{% block header_title %}Home{% endblock %}
+
+{% block content %}
+<p class="lead">RSS-TTS converts articles to audio. More features coming soon.</p>
+{% endblock %}

--- a/text_to_audio/templates/partials/_footer.html
+++ b/text_to_audio/templates/partials/_footer.html
@@ -1,0 +1,5 @@
+<footer class="py-3 mt-5 border-top bg-light">
+  <div class="container text-center">
+    <span class="text-muted">&copy; 2025 RSS-TTS</span>
+  </div>
+</footer>

--- a/text_to_audio/templates/partials/_header.html
+++ b/text_to_audio/templates/partials/_header.html
@@ -1,0 +1,5 @@
+<header class="py-3 bg-light border-bottom">
+  <div class="container">
+    <h1 class="display-6">{% block header_title %}Welcome to RSS-TTS{% endblock %}</h1>
+  </div>
+</header>

--- a/text_to_audio/templates/partials/_nav.html
+++ b/text_to_audio/templates/partials/_nav.html
@@ -1,0 +1,5 @@
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">RSS-TTS</a>
+  </div>
+</nav>

--- a/text_to_audio/views.py
+++ b/text_to_audio/views.py
@@ -1,0 +1,7 @@
+from django.views.generic import TemplateView
+
+
+class HomeView(TemplateView):
+    """Basic home page view."""
+
+    template_name = "index.html"


### PR DESCRIPTION
## Summary
- integrate Bootstrap base template and partials
- add simple home view and route
- document Dockerfile Celery dependency comment
- cover new templates with unit tests

## Testing
- `python manage.py test tests`