### PR TITLE
feat: Add pre-commit setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,15 @@ We use several tools to maintain code quality:
 - **Flake8**: For linting
 - **mypy**: For type checking
 
-Install pre-commit hooks to automatically run these tools:
+Install pre-commit hooks to automatically run these tools. You can run the
+commands manually or execute the provided helper script:
 
 ```bash
-pip install pre-commit
-pre-commit install
+./setup_precommit.sh
 ```
+
+The script installs the `pre-commit` package if needed and configures the git
+hooks for you.
 
 ### Coding Standards
 

--- a/setup_precommit.sh
+++ b/setup_precommit.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Install pre-commit if not available
+if ! command -v pre-commit >/dev/null 2>&1; then
+  echo "Installing pre-commit..."
+  pip install pre-commit
+fi
+
+# Install git hooks
+pre-commit install
+
+# Update to the latest hooks defined in config
+pre-commit autoupdate
+
+echo "Pre-commit hooks installed and updated."

--- a/tests/test_precommit_setup.py
+++ b/tests/test_precommit_setup.py
@@ -1,0 +1,41 @@
+"""Tests for the pre-commit setup script."""
+
+import os
+import stat
+import unittest
+
+
+class TestPrecommitSetup(unittest.TestCase):
+    """Validate the setup_precommit.sh script."""
+
+    SCRIPT_PATH = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "setup_precommit.sh"
+    )
+
+    def test_script_exists(self):
+        """Ensure the script file exists."""
+        self.assertTrue(
+            os.path.isfile(self.SCRIPT_PATH), "setup_precommit.sh should exist"
+        )
+
+    def test_script_executable(self):
+        """Ensure the script is executable."""
+        if not os.path.isfile(self.SCRIPT_PATH):
+            self.skipTest("setup_precommit.sh missing")
+        st = os.stat(self.SCRIPT_PATH)
+        self.assertTrue(
+            st.st_mode & stat.S_IEXEC, "setup_precommit.sh should be executable"
+        )
+
+    def test_script_contains_commands(self):
+        """Check that the script installs and configures pre-commit."""
+        if not os.path.isfile(self.SCRIPT_PATH):
+            self.skipTest("setup_precommit.sh missing")
+        with open(self.SCRIPT_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("pre-commit install", content)
+        self.assertIn("pip install pre-commit", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add \ script to install and configure pre-commit hooks
- Update README with instructions on using the script
- Add tests for the pre-commit setup script

## Changes
This PR adds a helper script that simplifies the process of setting up pre-commit hooks. Instead of manually running multiple commands, developers can now execute \pre-commit installed at .git/hooks/pre-commit
[https://github.com/pre-commit/pre-commit-hooks] updating v4.4.0 -> v5.0.0
[https://github.com/pre-commit/mirrors-autopep8] already up to date!
[https://github.com/psf/black] updating 23.7.0 -> 25.1.0
[https://github.com/pycqa/isort] updating 5.12.0 -> 6.0.1
[https://github.com/pycqa/flake8] updating 6.1.0 -> 7.2.0
[https://github.com/pre-commit/mirrors-mypy] updating v1.5.1 -> v1.15.0
Pre-commit hooks installed and updated. to install pre-commit and configure the hooks.

The README has been updated to document this new workflow. Tests are included to verify the script exists, is executable, and contains the necessary commands.

This PR extracts just the pre-commit script functionality from PR #36, without any of the GitHub Actions workflow changes that had issues.

## Test plan
- [x] Verify script installs pre-commit if not present
- [x] Verify script configures git hooks properly
- [x] Run unit tests: \