### PR TITLE
Fix Docker build permissions for GHCR

### DIFF
--- a/.github/workflows/99-deploy.yml
+++ b/.github/workflows/99-deploy.yml
@@ -24,6 +24,9 @@ jobs:
   build-and-push:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### **User description**
Adds explicit write permissions for packages to the Docker build workflow to fix the 403 Forbidden error when pushing to GitHub Container Registry.


___

### **PR Type**
Bug fix


___

### **Description**
Add permissions block to deploy workflow
Grant contents read permission
Grant packages write permission


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>99-deploy.yml</strong><dd><code>Configure permissions in deploy workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/99-deploy.yml

<li>Add permissions block to build-and-push job<br> <li> Set <code>contents</code> permission to <code>read</code><br> <li> Set <code>packages</code> permission to <code>write</code>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/41/files#diff-a7e04c6c3af33ff2b170a9fa79ead1eca714b74460c0cba641c4b1df383fb851">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>