### PR TITLE
Fix: Improve MP3 compatibility for Apple Podcasts

### DIFF
--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -279,11 +279,45 @@ def process_article(self, article_id: int) -> str:
             raise ValueError("No audio files were generated from chunks.")
 
         # Stitch audio files
+        # Define ID3 tags and export parameters
+        feed_name = "My Podcast"
+        if article.feed and article.feed.name:
+            feed_name = article.feed.name
+        elif hasattr(article, "feed") and hasattr(article.feed, "name") and article.feed.name is None: # Handle case where feed.name is explicitly None
+            feed_name = "My Podcast"
+
+
+        tags_dict = {
+            "title": article.title if article.title else "Untitled Article",
+            "artist": feed_name,
+            "album": feed_name,
+        }
+        export_parameters = ['-id3v2_version', '3', '-write_id3v1', '1']
+
+        final_audio_path = article_media_dir / f"article_{article.audio_uuid}.mp3"
+
         if len(temp_audio_files) == 1:
-            final_audio_path_temp = temp_audio_files[0]
-            final_audio_path = article_media_dir / f"article_{article.audio_uuid}.mp3"
-            final_audio_path_temp.rename(final_audio_path)
-            logger.info(f"Single audio chunk moved to {final_audio_path}")
+            temp_single_audio_path = temp_audio_files[0]
+            try:
+                audio_segment = AudioSegment.from_mp3(temp_single_audio_path)
+                audio_segment = audio_segment.set_frame_rate(44100)
+                audio_segment.export(
+                    final_audio_path,
+                    format="mp3",
+                    bitrate="128k",
+                    tags=tags_dict,
+                    parameters=export_parameters,
+                )
+                logger.info(
+                    f"Processed single audio chunk and exported to {final_audio_path}"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Error processing single audio chunk {temp_single_audio_path}: {e}"
+                )
+                raise ValueError(
+                    f"Failed to process single audio chunk {temp_single_audio_path.name}: {e}"
+                ) from e
         else:
             combined_audio = AudioSegment.empty()
             for temp_file in temp_audio_files:
@@ -292,17 +326,26 @@ def process_article(self, article_id: int) -> str:
                     combined_audio += segment
                 except Exception as e:  # pydub can raise various errors
                     logger.error(
-                        f"Pydub error: chunk {temp_file} article {article_id}: {e}"
+                        f"Pydub error processing chunk {temp_file} for article {article_id}: {e}"
                     )
                     raise ValueError(
                         f"Failed to process audio chunk {temp_file.name}: {e}"
                     ) from e
 
-            final_audio_path = article_media_dir / f"article_{article.audio_uuid}.mp3"
-            combined_audio.export(final_audio_path, format="mp3")
-            logger.info(
-                f"Combined {len(temp_audio_files)} audio chunks into {final_audio_path}"
-            )
+            if combined_audio:
+                combined_audio = combined_audio.set_frame_rate(44100)
+                combined_audio.export(
+                    final_audio_path,
+                    format="mp3",
+                    bitrate="128k",
+                    tags=tags_dict,
+                    parameters=export_parameters,
+                )
+                logger.info(
+                    f"Combined {len(temp_audio_files)} audio chunks and exported to {final_audio_path}"
+                )
+            else:
+                raise ValueError("Combined audio is empty, cannot export.")
 
         article.audio_file_path = str(final_audio_path.relative_to(media_root))
         article.status = Article.COMPLETED


### PR DESCRIPTION
The generated MP3 files were reportedly not playable in Apple Podcasts, although they worked in VLC. This was likely due to a combination of audio encoding parameters and missing metadata.

This commit modifies the MP3 generation process in `text_to_audio/tasks.py` to align with common Apple Podcasts requirements:

1.  **Set Sample Rate to 44.1kHz:** Audio is now explicitly converted to 44.1kHz, a widely supported sample rate, from OpenAI's default 24kHz.
2.  **Use Constant Bitrate (CBR) 128kbps:** MP3s are now exported at 128kbps CBR, which is generally more robustly supported by Apple devices than Variable Bitrate (VBR) for podcasts.
3.  **Add ID3v2.3 Tags:** Essential ID3 tags (title, artist, album) are now embedded in the MP3 files using the ID3v2.3 standard. Default values are provided if article or feed information is missing.

These changes apply to both single-chunk and multi-chunk audio articles, ensuring all output MP3s receive the same treatment. The testing plan involves generating new MP3s, inspecting their properties, and verifying playback in Apple Podcasts, ideally via an RSS feed.