### PR TITLE
Fix failing article submission tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "dockerComposeFile": ".devcontainer/docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/app",
+  "runServices": ["app", "caddy"],
   "forwardPorts": [8000, 8084],
   "customizations": {
     "vscode": {

--- a/tests/test_article_flow.py
+++ b/tests/test_article_flow.py
@@ -6,8 +6,9 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
+from django.urls import reverse
 
-from text_to_audio.models import Article
+from text_to_audio.models import Article, Feed
 
 
 class TestArticleSubmissionFlow(TestCase):
@@ -19,17 +20,19 @@ class TestArticleSubmissionFlow(TestCase):
         self.user = get_user_model().objects.create_user(
             username="flowtester", password="pass123"
         )
+        self.feed = Feed.objects.create(user=self.user, name="Default")
 
     def test_submission_triggers_processing_task(self):
         """Test that article submission triggers the processing task."""
         self.client.login(username="flowtester", password="pass123")
         with patch("text_to_audio.views.process_article.delay") as mock_delay:
             response = self.client.post(
-                "/articles/submit/",
+                reverse("feed-article-create", kwargs={"feed_id": self.feed.pk}),
                 {"title": "Flow Test", "text_content": "Sample"},
             )
             self.assertEqual(response.status_code, 302)
             article = Article.objects.get(title="Flow Test")
+            self.assertEqual(article.feed, self.feed)
             self.assertEqual(article.status, Article.PROCESSING)
             mock_delay.assert_called_once_with(article.id)
 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -3,10 +3,12 @@
 # mypy: disable-error-code="attr-defined"
 
 import os
+from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
+from django.urls import reverse
 
 from text_to_audio.models import Article, Feed
 
@@ -85,18 +87,22 @@ class TestArticleSubmission(TestCase):
         """Test that authenticated users can access the article submission form."""
         self.client.login(username="tester", password="pass123")
         response = self.client.get("/articles/submit/")
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "article_form.html")
+        expected_url = reverse("feed-article-create", kwargs={"feed_id": self.feed.pk})
+        self.assertRedirects(response, expected_url)
 
     def test_post_creates_article(self):
         """Test that submitting the article form creates a new article."""
         self.client.login(username="tester", password="pass123")
-        response = self.client.post(
-            "/articles/submit/",
-            {"title": "Test", "text_content": "Hello"},
-        )
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(Article.objects.filter(title="Test").exists())
+        with mock.patch("text_to_audio.views.process_article.delay") as mock_delay:
+            response = self.client.post(
+                reverse("feed-article-create", kwargs={"feed_id": self.feed.pk}),
+                {"title": "Test", "text_content": "Hello"},
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertTrue(
+                Article.objects.filter(title="Test", feed=self.feed).exists()
+            )
+            mock_delay.assert_called_once()
 
 
 class TestLogoutView(TestCase):


### PR DESCRIPTION
### **User description**
## Notes
- Updated frontend and flow tests to handle new feed-based article creation redirect.
- Adjusted devcontainer.json so project structure tests pass.

## Summary
- Expect `/articles/submit/` to redirect to feed-specific submission.
- Use `feed-article-create` URL in POST tests and mock Celery task.
- Ensure article is linked to the correct feed after creation.
- Added `runServices` in devcontainer config.

## Testing
- `python run_all_tests_with_mock.py`
- `pre-commit` *(fails: Unable to fetch hooks due to no network)*


___

### **PR Type**
Tests


___

### **Description**
- Update article flow tests for feed-based submission

- Adjust frontend tests to expect feed redirects

- Mock Celery task and verify feed association

- Add caddy to devcontainer runServices


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_article_flow.py</strong><dd><code>Use feed-based URL and assert feed link in flow tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_article_flow.py

<li>Import <code>reverse</code> and <code>Feed</code> model<br> <li> Create a feed instance in <code>setUp</code><br> <li> Use <code>reverse("feed-article-create", ...)</code> for POST URL<br> <li> Assert <code>article.feed</code> equals the created feed


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/63/files#diff-ba5ed365eb73c6a64c6b5c979405b3ec1fdbd4b60748db2a3d24db6f0f0c922b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_frontend.py</strong><dd><code>Update frontend tests for feed-specific routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_frontend.py

<li>Import <code>mock</code> and <code>reverse</code><br> <li> Expect GET to <code>/articles/submit/</code> to redirect to feed URL<br> <li> Use <code>reverse("feed-article-create", ...)</code> for POST<br> <li> Mock Celery delay and assert feed association on article


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/63/files#diff-c9bfdde749a4a61e65f7397be900e272dafb23c05fccdde91d2cc6168d5ab49e">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devcontainer.json</strong><dd><code>Enable caddy service in devcontainer config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/devcontainer.json

<li>Add <code>"runServices": ["app", "caddy"]</code> entry<br> <li> Ensure caddy service runs in devcontainer environment


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/63/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>