### PR TITLE
fix: Address linting issues and transaction handling in OpenAI stats

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,14 +7,14 @@ import uuid
 from importlib import util
 
 from django.conf import settings
-from django.contrib.auth import get_user_model # type: ignore
+from django.contrib.auth import get_user_model  # type: ignore
 from django.db import models
 from django.test import TestCase
 
 # Import models needed for tests
-from text_to_audio.models import Feed, Article, OpenAIUsageStats
+from text_to_audio.models import Article, Feed, OpenAIUsageStats
 
-User = get_user_model() # type: ignore
+User = get_user_model()  # type: ignore
 
 
 class TestModels(TestCase):
@@ -140,7 +140,8 @@ class OpenAIUsageStatsModelTests(TestCase):
 
     def setUp(self):
         """Set up test data."""
-        self.user = User.objects.create_user(
+        # Type ignore - Django's get_user_model() doesn't expose create_user
+        self.user = User.objects.create_user(  # type: ignore
             username="statsuser", email="stats@example.com", password="testpass123"
         )
         self.feed = Feed.objects.create(user=self.user, name="Stats Feed")
@@ -165,19 +166,35 @@ class OpenAIUsageStatsModelTests(TestCase):
         self.assertTrue(hasattr(OpenAIUsageStats, "request_timestamp"))
 
         # Check field types
-        self.assertIsInstance(OpenAIUsageStats._meta.get_field("user"), models.ForeignKey)
-        self.assertIsInstance(OpenAIUsageStats._meta.get_field("article"), models.ForeignKey)
-        self.assertIsInstance(OpenAIUsageStats._meta.get_field("tokens_used"), models.IntegerField)
-        self.assertIsInstance(OpenAIUsageStats._meta.get_field("processing_time_ms"), models.IntegerField)
-        self.assertIsInstance(OpenAIUsageStats._meta.get_field("word_count"), models.IntegerField)
-        self.assertIsInstance(OpenAIUsageStats._meta.get_field("request_timestamp"), models.DateTimeField)
+        self.assertIsInstance(
+            OpenAIUsageStats._meta.get_field("user"), models.ForeignKey
+        )
+        self.assertIsInstance(
+            OpenAIUsageStats._meta.get_field("article"), models.ForeignKey
+        )
+        self.assertIsInstance(
+            OpenAIUsageStats._meta.get_field("tokens_used"), models.IntegerField
+        )
+        self.assertIsInstance(
+            OpenAIUsageStats._meta.get_field("processing_time_ms"), models.IntegerField
+        )
+        self.assertIsInstance(
+            OpenAIUsageStats._meta.get_field("word_count"), models.IntegerField
+        )
+        self.assertIsInstance(
+            OpenAIUsageStats._meta.get_field("request_timestamp"), models.DateTimeField
+        )
 
         # Check field attributes
         self.assertEqual(OpenAIUsageStats._meta.get_field("user").related_model, User)
-        self.assertEqual(OpenAIUsageStats._meta.get_field("article").related_model, Article)
-        self.assertTrue(OpenAIUsageStats._meta.get_field("article").null) # Check if article can be null
-        self.assertTrue(OpenAIUsageStats._meta.get_field("request_timestamp").auto_now_add)
-
+        self.assertEqual(
+            OpenAIUsageStats._meta.get_field("article").related_model, Article
+        )
+        # Check if article can be null
+        self.assertTrue(OpenAIUsageStats._meta.get_field("article").null)
+        self.assertTrue(
+            OpenAIUsageStats._meta.get_field("request_timestamp").auto_now_add
+        )
 
     def test_create_stats_with_article(self):
         """Test creating an OpenAIUsageStats instance with an article."""
@@ -220,19 +237,23 @@ class OpenAIUsageStatsModelTests(TestCase):
             processing_time_ms=500,
             word_count=50,
         )
-        expected_str = f"Usage for {self.user.username} at {stats.request_timestamp:%Y-%m-%d %H:%M:%S}"
+        # Format timestamp for comparison with __str__ output
+        timestamp_fmt = stats.request_timestamp.strftime("%Y-%m-%d %H:%M:%S")
+        expected_str = f"Usage for {self.user.username} at {timestamp_fmt}"
         self.assertEqual(str(stats), expected_str)
 
     def test_str_method_no_article(self):
         """Test the __str__ method when article is None (should be same)."""
         stats = OpenAIUsageStats.objects.create(
             user=self.user,
-            article=None, # No article
+            article=None,  # No article
             tokens_used=150,
             processing_time_ms=550,
             word_count=55,
         )
-        expected_str = f"Usage for {self.user.username} at {stats.request_timestamp:%Y-%m-%d %H:%M:%S}"
+        # Format timestamp for comparison with __str__ output
+        timestamp_fmt = stats.request_timestamp.strftime("%Y-%m-%d %H:%M:%S")
+        expected_str = f"Usage for {self.user.username} at {timestamp_fmt}"
         self.assertEqual(str(stats), expected_str)
 
 

--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -394,6 +394,7 @@ class ProcessArticleTests(TestCase):
 
     @patch("text_to_audio.tasks.AudioSegment.from_mp3")
     @patch("text_to_audio.tasks.AudioSegment.empty")
+    @patch("django.db.transaction.atomic", lambda inner_func=None: inner_func)
     def test_process_article_stat_saving_error(
         self, mock_audio_empty, mock_audio_from_mp3, MockOpenAIClient
     ):


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Refine tests formatting and readability

- Add type ignores and import spacing corrections

- Use explicit timestamp formatting in __str__ tests

- Patch transaction.atomic in task tests


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_models.py</strong><dd><code>Refactor OpenAIUsageStats model test formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_models.py

<li>Standardize import spacing and add type ignores<br> <li> Refactor assertIsInstance calls to multi-line<br> <li> Add comments for null and timestamp checks<br> <li> Use explicit timestamp formatting in __str__ tests


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/64/files#diff-0adb667cd397bd56edce10eec11e1b10821740a10d72bd148b09645fc9108968">+38/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_tasks.py</strong><dd><code>Patch transaction.atomic in process_article test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/text_to_audio/test_tasks.py

- Add patch for django.db.transaction.atomic decorator


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/64/files#diff-92b9935e180b5c885c30de11967e5900573cb0a2eef0b8581615d4224a58d18a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>