### PR TITLE
Fix tests for devcontainer config

### DIFF
--- a/tests/test_article_flow.py
+++ b/tests/test_article_flow.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 
-from text_to_audio.models import Article
+from text_to_audio.models import Article, Feed
 
 
 class TestArticleSubmissionFlow(TestCase):
@@ -19,13 +19,14 @@ class TestArticleSubmissionFlow(TestCase):
         self.user = get_user_model().objects.create_user(
             username="flowtester", password="pass123"
         )
+        self.feed = Feed.objects.create(user=self.user, name="Default")
 
     def test_submission_triggers_processing_task(self):
         """Test that article submission triggers the processing task."""
         self.client.login(username="flowtester", password="pass123")
         with patch("text_to_audio.views.process_article.delay") as mock_delay:
             response = self.client.post(
-                "/articles/submit/",
+                f"/feeds/{self.feed.pk}/add/",
                 {"title": "Flow Test", "text_content": "Sample"},
             )
             self.assertEqual(response.status_code, 302)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -3,6 +3,7 @@
 # mypy: disable-error-code="attr-defined"
 
 import os
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -85,18 +86,24 @@ class TestArticleSubmission(TestCase):
         """Test that authenticated users can access the article submission form."""
         self.client.login(username="tester", password="pass123")
         response = self.client.get("/articles/submit/")
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "article_form.html")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(f"/feeds/{self.feed.pk}/add/", response["Location"])
+
+        follow_response = self.client.get(response["Location"])
+        self.assertEqual(follow_response.status_code, 200)
+        self.assertTemplateUsed(follow_response, "article_form.html")
 
     def test_post_creates_article(self):
         """Test that submitting the article form creates a new article."""
         self.client.login(username="tester", password="pass123")
-        response = self.client.post(
-            "/articles/submit/",
-            {"title": "Test", "text_content": "Hello"},
-        )
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(Article.objects.filter(title="Test").exists())
+        with patch("text_to_audio.views.process_article.delay") as mock_delay:
+            response = self.client.post(
+                f"/feeds/{self.feed.pk}/add/",
+                {"title": "Test", "text_content": "Hello"},
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertTrue(Article.objects.filter(title="Test").exists())
+            mock_delay.assert_called_once()
 
 
 class TestLogoutView(TestCase):

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -42,10 +42,12 @@ class TestProjectStructure(unittest.TestCase):
         with open(os.path.join(".devcontainer", "devcontainer.json")) as f:
             data = json.load(f)
 
-        self.assertIn("runServices", data)
-        # Redis should now run inside a service container, so it is not a
-        # separate service in runServices
-        self.assertNotIn("redis", data["runServices"])
+        self.assertIn("features", data)
+        self.assertIn(
+            "ghcr.io/devcontainers/features/docker-in-docker:1",
+            data["features"],
+        )
+        self.assertEqual(data.get("remoteUser"), "vscode")
 
     def test_docker_compose_has_redis_service(self):
         """Ensure docker-compose.yml defines a redis service."""


### PR DESCRIPTION
### **User description**
## Summary
- update devcontainer tests to check `features` not `runServices`
- update frontend tests to use feed-specific article creation
- adjust article flow test for feed-based view

## Testing
- `python run_all_tests_with_mock.py`


___

### **PR Type**
Tests


___

### **Description**
- Update article flow tests for feed-based endpoints

- Adjust frontend tests to follow feed redirects

- Modify project structure tests for `features`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_article_flow.py</strong><dd><code>Adapt article flow tests to feed endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_article_flow.py

<li>Import <code>Feed</code> model alongside <code>Article</code><br> <li> Create <code>self.feed</code> in setUp for tests<br> <li> Use feed-specific <code>/feeds/{self.feed.pk}/add/</code> URL


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/67/files#diff-ba5ed365eb73c6a64c6b5c979405b3ec1fdbd4b60748db2a3d24db6f0f0c922b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_frontend.py</strong><dd><code>Adjust frontend tests for feed redirects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_frontend.py

<li>Add <code>patch</code> import for mocking tasks<br> <li> Update GET test to follow <code>/feeds/{self.feed.pk}/add/</code> redirect<br> <li> Change POST to feed add endpoint with <code>process_article.delay</code>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/67/files#diff-c9bfdde749a4a61e65f7397be900e272dafb23c05fccdde91d2cc6168d5ab49e">+15/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_project_structure.py</strong><dd><code>Verify devcontainer features configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_project_structure.py

<li>Assert <code>features</code> key in <code>.devcontainer/devcontainer.json</code><br> <li> Check <code>ghcr.io/devcontainers/features/docker-in-docker:1</code><br> <li> Verify <code>remoteUser</code> equals <code>vscode</code>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/67/files#diff-162c28f03e1145439445e3407030d1ac8c8490e2c902d59f685c1f9f6e6143ae">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>