### PR TITLE
Add summary generation for RSS articles

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -75,6 +75,7 @@ class TestModels(TestCase):
             self.assertTrue(hasattr(Article, "title"))
             self.assertTrue(hasattr(Article, "source_url"))
             self.assertTrue(hasattr(Article, "text_content"))
+            self.assertTrue(hasattr(Article, "summary"))
             self.assertTrue(hasattr(Article, "audio_file_path"))
             self.assertTrue(hasattr(Article, "status"))
             self.assertTrue(hasattr(Article, "created_at"))
@@ -88,6 +89,7 @@ class TestModels(TestCase):
             self.assertIsInstance(
                 Article._meta.get_field("text_content"), models.TextField
             )
+            self.assertIsInstance(Article._meta.get_field("summary"), models.TextField)
             self.assertIsInstance(
                 Article._meta.get_field("audio_file_path"), models.CharField
             )
@@ -101,6 +103,7 @@ class TestModels(TestCase):
             self.assertEqual(Article._meta.get_field("title").max_length, 255)
             self.assertEqual(Article._meta.get_field("audio_file_path").max_length, 255)
             self.assertTrue(Article._meta.get_field("created_at").auto_now_add)
+            self.assertTrue(Article._meta.get_field("summary").blank)
 
             # Check status choices
             self.assertTrue(hasattr(Article, "STATUS_CHOICES"))

--- a/tests/test_rss_summary.py
+++ b/tests/test_rss_summary.py
@@ -1,0 +1,30 @@
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from text_to_audio.models import Article, Feed
+
+
+class RssSummaryTests(TestCase):
+    """Tests for summary inclusion in RSS feed."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = get_user_model().objects.create_user(  # type: ignore[attr-defined]
+            username="rssuser", password="pass123"
+        )
+        self.feed = Feed.objects.create(user=self.user, name="Test Feed")
+        self.article = Article.objects.create(
+            feed=self.feed,
+            title="Summary Article",
+            text_content="body",
+            summary="A short summary.",
+            audio_file_path="dummy.mp3",
+            audio_uuid="123e4567-e89b-12d3-a456-426614174000",
+            status=Article.COMPLETED,
+        )
+
+    def test_summary_in_feed(self):
+        response = self.client.get(reverse("feed", args=[self.feed.token]))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("A short summary.", response.content.decode())

--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -315,6 +315,44 @@ class ProcessArticleTests(TestCase):
             # Check word count (sample text has 11 words)
             self.assertEqual(stats_obj.word_count, 11)
 
+    @patch("text_to_audio.tasks._generate_summary", return_value="Test summary")
+    @patch("text_to_audio.tasks.AudioSegment.from_mp3")
+    @patch("text_to_audio.tasks.AudioSegment.empty")
+    def test_process_article_saves_summary(
+        self,
+        mock_audio_empty,
+        mock_audio_from_mp3,
+        mock_generate_summary,
+        MockOpenAIClient,
+    ):
+        """Test that process_article stores the generated summary."""
+        mock_openai_instance = MockOpenAIClient.return_value
+        mock_speech_create = mock_openai_instance.audio.speech.create
+
+        mock_tts_response = MagicMock()
+        mock_tts_response.usage = MagicMock(total_tokens=10)
+        mock_tts_response.stream_to_file.side_effect = (
+            self.create_dummy_file_side_effect
+        )
+        mock_speech_create.return_value = mock_tts_response
+
+        mock_audio_segment = MagicMock()
+        mock_audio_segment.set_frame_rate.return_value = mock_audio_segment
+
+        def export_side_effect(*args, **kwargs):
+            path_arg = args[0] if args else kwargs.get("out_f")
+            if path_arg:
+                self.create_dummy_file_side_effect(path_arg)
+            return None
+
+        mock_audio_segment.export.side_effect = export_side_effect
+        mock_audio_from_mp3.return_value = mock_audio_segment
+        mock_audio_empty.return_value = MagicMock()
+
+        process_article(self.article.id)
+        self.article.refresh_from_db()
+        self.assertEqual(self.article.summary, "Test summary")
+
     def test_process_article_success_multiple_chunks(self, MockOpenAIClient):
         """Test processing an article with multiple text chunks."""
         # Test that our path works for combining multiple audio files

--- a/text_to_audio/feeds.py
+++ b/text_to_audio/feeds.py
@@ -121,7 +121,8 @@ class UserFeed(Feed):
 
     def item_description(self, item: Article) -> str:
         """Get the description for a feed item."""
-        # Include a link to the original article if available
+        if item.summary:
+            return str(item.summary)
         if item.source_url:
             return f"Audio version of <a href='{item.source_url}'>{item.title}</a>"
         return "Audio version of article"

--- a/text_to_audio/migrations/0008_article_summary.py
+++ b/text_to_audio/migrations/0008_article_summary.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("text_to_audio", "0007_openaiusagestats"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="article",
+            name="summary",
+            field=models.TextField(
+                blank=True,
+                help_text="Summary of the article in 100 words or less.",
+            ),
+        ),
+    ]

--- a/text_to_audio/models.py
+++ b/text_to_audio/models.py
@@ -73,6 +73,10 @@ class Article(models.Model):
     text_content: models.TextField = models.TextField(
         null=False, blank=True, help_text="The text content of the article."
     )
+    summary: models.TextField = models.TextField(
+        blank=True,
+        help_text="Summary of the article in 100 words or less.",
+    )
     audio_file_path: models.CharField = models.CharField(
         max_length=255, blank=True, help_text="Path to the audio file."
     )

--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -210,6 +210,24 @@ def _chunk_text(text: str, max_length: int = 4000) -> tuple[bool, list[str]]:
     return perfect_split, chunks
 
 
+def _generate_summary(text: str) -> str:
+    """Generate a summary of the text using OpenAI's o4-mini model."""
+    try:
+        client = openai.OpenAI(api_key=settings.OPENAI_API_KEY)
+        prompt = "Summarize the following article in 100 words or less:\n\n" + text
+        response = client.chat.completions.create(
+            model=getattr(settings, "OPENAI_SUMMARY_MODEL", "o4-mini"),
+            messages=[{"role": "user", "content": prompt}],
+        )
+        summary = ""
+        if hasattr(response, "choices") and response.choices:
+            summary = str(response.choices[0].message.content).strip()
+        return summary
+    except Exception as exc:  # pragma: no cover - fallback path
+        logger.error(f"Summary generation failed: {exc}")
+        return ""
+
+
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
 def process_article(self, article_id: int) -> str:
     """Process an article's text_content to generate an MP3 audio file.
@@ -280,6 +298,11 @@ def process_article(self, article_id: int) -> str:
 
         if not article.text_content:
             raise ValueError("Article text_content is empty.")
+
+        # Generate summary before converting to audio
+        summary = _generate_summary(article.text_content)
+        article.summary = summary
+        article.save(update_fields=["summary"])
 
         # Get text chunks with default max_length of 4000
         success, text_chunks = _chunk_text(article.text_content)

--- a/text_to_audio/tasks_mock.py
+++ b/text_to_audio/tasks_mock.py
@@ -190,6 +190,13 @@ def _chunk_text(text: str, max_length: int = 4000) -> tuple[bool, list[str]]:
     return perfect_split, chunks
 
 
+def _generate_summary(text: str) -> str:
+    """Return a simple first-sentence summary for tests."""
+    if not text:
+        return ""
+    return text.split(".")[0].strip()
+
+
 # flake8: noqa: C901
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
 def process_article(self, article_id: int) -> str:
@@ -266,6 +273,10 @@ def process_article(self, article_id: int) -> str:
 
         if not article.text_content:
             raise ValueError("Article text_content is empty.")
+
+        summary = _generate_summary(article.text_content)
+        article.summary = summary
+        article.save(update_fields=["summary"])
 
         # Get text chunks with default max_length of 4000
         success, text_chunks = _chunk_text(article.text_content)


### PR DESCRIPTION
## Summary
- allow storing article summaries
- generate summary using o4-mini in the article processing task
- include article summary in RSS feed items
- add migration for Article.summary field
- test summary behaviour in models, tasks and RSS feed

## Testing
- `isort` on changed files
- `black` on changed files
- `flake8` on changed files
- `mypy` on changed files
- `python run_all_tests_with_mock.py`