### PR TITLE
fix speed auto default

### DIFF
--- a/tests/test_article_flow.py
+++ b/tests/test_article_flow.py
@@ -49,6 +49,26 @@ class TestArticleSubmissionFlow(TestCase):
             self.assertEqual(article.speed, 1.25)
             mock_delay.assert_called_once_with(article.id)
 
+    def test_submission_defaults_to_auto_speed(self):
+        """Missing speed field should save speed as None."""
+        self.client.login(username="flowtester", password="pass123")
+        with patch("text_to_audio.views.process_article.delay") as mock_delay:
+            mock_task = MagicMock()
+            mock_task.id = "task-id"
+            mock_delay.return_value = mock_task
+
+            response = self.client.post(
+                f"/feeds/{self.feed.pk}/add/",
+                {
+                    "title": "No Speed",
+                    "text_content": "Sample",
+                },
+            )
+            self.assertEqual(response.status_code, 302)
+            article = Article.objects.get(title="No Speed")
+            self.assertIsNone(article.speed)
+            mock_delay.assert_called_once_with(article.id)
+
 
 # For pytest compatibility
 if __name__ == "__main__":

--- a/text_to_audio/forms.py
+++ b/text_to_audio/forms.py
@@ -57,21 +57,27 @@ class ArticleSubmissionForm(forms.ModelForm):
             ("", "Auto (detect from tone)")
         ] + voice_service.get_available_speeds()
 
-        self.fields["voice_id"].choices = voice_choices
-        self.fields["speed"].choices = speed_choices
+        from typing import cast
+
+        voice_field = cast(forms.ChoiceField, self.fields["voice_id"])
+        voice_field.choices = voice_choices
+        speed_field = cast(forms.ChoiceField, self.fields["speed"])
+        speed_field.choices = speed_choices
 
         # Set user presets if user is provided
         preset_choices = [("", "Don't use a preset")]
         if user and user.is_authenticated:
             preset_choices += voice_service.get_user_presets(user)
 
-        self.fields["voice_preset"].choices = preset_choices
+        preset_field = cast(forms.ChoiceField, self.fields["voice_preset"])
+        preset_field.choices = preset_choices
 
     def clean(self):
         """Validate that either source_url or text_content is provided."""
         cleaned_data = super().clean()
         if cleaned_data is None:
             return cleaned_data
+        assert cleaned_data is not None
 
         source_url = cleaned_data.get("source_url", "")
         text_content = cleaned_data.get("text_content", "")
@@ -86,10 +92,23 @@ class ArticleSubmissionForm(forms.ModelForm):
         if voice_preset and (voice_id or speed):
             self.add_error(
                 "voice_preset",
-                "You cannot select both a voice preset and individual voice/speed settings.",
+                (
+                    "You cannot select both a voice preset and "
+                    "individual voice/speed settings."
+                ),
             )
 
         return cleaned_data
+
+    def clean_speed(self) -> float | None:
+        """Convert blank speed values to ``None``."""
+        value = self.cleaned_data.get("speed")
+        if value in ("", None):
+            return None
+        try:
+            return float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValidationError("Invalid speed value")
 
 
 class UserVoicePreferenceForm(forms.ModelForm):
@@ -126,6 +145,16 @@ class UserVoicePreferenceForm(forms.ModelForm):
             help_text="Your preferred speaking speed for all articles.",
         )
 
+    def clean_preferred_speed(self) -> float | None:
+        """Convert blank speed values to ``None`` and return float."""
+        value = self.cleaned_data.get("preferred_speed")
+        if value in ("", None):
+            return None
+        try:
+            return float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValidationError("Invalid speed value")
+
 
 class ArticleVoiceForm(forms.Form):
     """Form for article-specific voice settings."""
@@ -156,10 +185,17 @@ class ArticleVoiceForm(forms.Form):
         ] + voice_service.get_available_speeds()
 
         # Need to check if field exists and has a choices attribute before setting
-        if "voice_id" in self.fields and hasattr(self.fields["voice_id"], "choices"):
-            self.fields["voice_id"].choices = voice_choices
-        if "speed" in self.fields and hasattr(self.fields["speed"], "choices"):
-            self.fields["speed"].choices = speed_choices
+        if "voice_id" in self.fields:
+            from typing import cast
+
+            voice_field = cast(forms.ChoiceField, self.fields["voice_id"])
+            voice_field.choices = voice_choices
+
+        if "speed" in self.fields:
+            from typing import cast
+
+            speed_field = cast(forms.ChoiceField, self.fields["speed"])
+            speed_field.choices = speed_choices
 
         # Set user presets if user is provided
         preset_choices = [("", "Don't use a preset")]
@@ -172,8 +208,9 @@ class ArticleVoiceForm(forms.Form):
             self.fields["voice_preset"].choices = preset_choices
 
     def clean(self):
-        """Validate that voice preset and direct voice/speed settings are not both set."""
+        """Validate that preset and direct settings aren't both set."""
         cleaned_data = super().clean()
+        assert cleaned_data is not None
 
         voice_preset = cleaned_data.get("voice_preset")
         voice_id = cleaned_data.get("voice_id")
@@ -182,16 +219,31 @@ class ArticleVoiceForm(forms.Form):
         if voice_preset and (voice_id or speed):
             self.add_error(
                 "voice_preset",
-                "You cannot select both a voice preset and individual voice/speed settings.",
+                (
+                    "You cannot select both a voice preset and "
+                    "individual voice/speed settings."
+                ),
             )
 
         return cleaned_data
+
+    def clean_speed(self) -> float | None:
+        """Convert blank speed values to ``None``."""
+        value = self.cleaned_data.get("speed")
+        if value in ("", None):
+            return None
+        try:
+            return float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValidationError("Invalid speed value")
 
 
 class ArticleDetailForm(forms.ModelForm):
     """Form for editing article details when regenerating."""
 
     class Meta:
+        """Meta options for the ArticleDetailForm."""
+
         model = Article
         fields = ["title", "text_content", "summary", "voice_id", "speed"]
         widgets = {
@@ -200,6 +252,7 @@ class ArticleDetailForm(forms.ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
+        """Initialize form with dynamic voice options."""
         super().__init__(*args, **kwargs)
         voice_service = VoiceConfigurationService()
         voice_choices = [
@@ -218,6 +271,16 @@ class ArticleDetailForm(forms.ModelForm):
             required=False,
             help_text="Speed for this article.",
         )
+
+    def clean_speed(self) -> float | None:
+        """Convert blank speed values to ``None``."""
+        value = self.cleaned_data.get("speed")
+        if value in ("", None):
+            return None
+        try:
+            return float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValidationError("Invalid speed value")
 
 
 class VoicePresetForm(forms.ModelForm):
@@ -285,12 +348,20 @@ class FeedForm(forms.ModelForm):
     )
 
     class Meta:
+        """Meta options for the FeedForm."""
+
         model = Feed
         fields = ["name", "default_voice_preset"]
 
     def __init__(self, *args, user=None, **kwargs):
+        """Initialize form and limit presets to the current user."""
         super().__init__(*args, **kwargs)
         if user and user.is_authenticated:
-            self.fields["default_voice_preset"].queryset = (
-                UserVoicePreset.objects.filter(user=user).order_by("name")
+            from typing import cast
+
+            preset_field = cast(
+                forms.ModelChoiceField, self.fields["default_voice_preset"]
+            )
+            preset_field.queryset = UserVoicePreset.objects.filter(user=user).order_by(
+                "name"
             )


### PR DESCRIPTION
### **User description**
## Summary
- default article speed to auto when no selection is made
- cast form fields to ensure mypy passes
- test missing speed saves `None`

## Testing
- `python run_single_test.py tests/test_article_flow.py`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Convert blank speed inputs to None.

- Cast voice/speed fields to ChoiceField.

- Add clean_speed and clean_preferred_speed methods.

- Add test for default auto speed behavior.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_article_flow.py</strong><dd><code>Test default auto speed None</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_article_flow.py

<li>Introduce test_submission_defaults_to_auto_speed.<br> <li> Verify missing speed saves as None.<br> <li> Ensure processing task is triggered.


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/108/files#diff-ba5ed365eb73c6a64c6b5c979405b3ec1fdbd4b60748db2a3d24db6f0f0c922b">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>forms.py</strong><dd><code>Cast fields and normalize blank speed values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/forms.py

<li>Cast voice_id, speed, and voice_preset fields.<br> <li> Implement clean_speed in multiple forms.<br> <li> Add clean_preferred_speed for user prefs.<br> <li> Add docstrings and type assertions.


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/108/files#diff-919d7b29a64923e322d5d43285eeb2f218e845ee9b2a0006d65a94785b109098">+83/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>