### PR TITLE
Persist auto voice parameters

### DIFF
--- a/tests/test_auto_voice.py
+++ b/tests/test_auto_voice.py
@@ -97,7 +97,14 @@ class GenreClassificationServiceTest(TestCase):
     def setUp(self):
         """Set up test data."""
         self.service = GenreClassificationService()
-        self.article_text = "Scientists have discovered a new species of butterfly in the Amazon rainforest. The discovery was made during an expedition led by Dr. Emily Carter, who specializes in tropical entomology. The butterfly, named Papilio amazonica, features vibrant blue wings with distinctive yellow patterns. This finding suggests the region's biodiversity may be even richer than previously thought."
+        self.article_text = (
+            "Scientists have discovered a new species of butterfly in the Amazon "
+            "rainforest. The discovery was made during an expedition led by Dr. "
+            "Emily Carter, who specializes in tropical entomology. The butterfly, "
+            "named Papilio amazonica, features vibrant blue wings with distinctive "
+            "yellow patterns. This finding suggests the region's biodiversity may "
+            "be even richer than previously thought."
+        )
 
     @patch(
         "text_to_audio.services.genre_classification.GenreClassificationService.client"
@@ -109,7 +116,13 @@ class GenreClassificationServiceTest(TestCase):
         mock_completion.choices = [
             MagicMock(
                 message=MagicMock(
-                    content='{"genre": "news", "confidence": 0.85, "voice_suggestions": {"affect": "neutral", "tone": "informative", "pacing": "steady", "pitch_variation": "moderate", "speaking_style": "Clear and factual news reporting style"}}'
+                    content=(
+                        '{"genre": "news", "confidence": 0.85, '
+                        '"voice_suggestions": {"affect": "neutral", '
+                        '"tone": "informative", "pacing": "steady", '
+                        '"pitch_variation": "moderate", "speaking_style": '
+                        '"Clear and factual news reporting style"}}'
+                    )
                 )
             )
         ]
@@ -145,10 +158,12 @@ class VoiceParameterGenerationServiceTest(TestCase):
         )
 
     @patch(
-        "text_to_audio.services.genre_classification.GenreClassificationService.classify_genre"
+        "text_to_audio.services.genre_classification."
+        "GenreClassificationService.classify_genre"
     )
     @patch(
-        "text_to_audio.services.content_analysis.ContentAnalysisService.analyze_content"
+        "text_to_audio.services.content_analysis."
+        "ContentAnalysisService.analyze_content"
     )
     def test_generate_voice_parameters(self, mock_analyze_content, mock_classify_genre):
         """Test voice parameter generation."""
@@ -207,7 +222,9 @@ class VoiceParameterGenerationServiceTest(TestCase):
             "tone": "authoritative, expert",
             "pacing": "measured",
             "pitch_variation": "moderate",
-            "speaking_style": "Like a university professor explaining an important concept",
+            "speaking_style": (
+                "Like a university professor explaining an important concept"
+            ),
         }
 
         prompt = self.service.generate_enhanced_prompt(params)
@@ -280,17 +297,25 @@ class FeedVoiceModeTest(TestCase):
         self.assertEqual(self.feed.voice_mode, Feed.VOICE_MODE_AUTO)
 
     @patch(
-        "text_to_audio.services.voice_parameter_generation.VoiceParameterGenerationService.generate_voice_parameters"
+        "text_to_audio.services.voice_parameter_generation."
+        "VoiceParameterGenerationService.generate_voice_parameters"
     )
     def test_configure_article_voice(self, mock_generate_voice_parameters):
-        """Test configuring article voice based on feed mode."""
+        """Test configuring article voice based on feed mode."""  # noqa: D202
+
         # Mock voice parameter generation
-        mock_generate_voice_parameters.return_value = {
-            "voice_id": "alloy",
-            "speed": 1.0,
-            "affect": "neutral",
-            "tone": "informative",
-        }
+        def fake_generate_params(article):
+            article.voice_id = "alloy"
+            article.speed = 1.0
+            article.voice_parameters = {
+                "voice_id": "alloy",
+                "speed": 1.0,
+                "affect": "neutral",
+                "tone": "informative",
+            }
+            return article.voice_parameters
+
+        mock_generate_voice_parameters.side_effect = fake_generate_params
 
         # Test single_default mode
         self.feed.voice_mode = Feed.VOICE_MODE_SINGLE_DEFAULT
@@ -335,3 +360,17 @@ class FeedVoiceModeTest(TestCase):
 
         # Verify generate_voice_parameters was called
         mock_generate_voice_parameters.assert_called_with(self.article)
+
+        # Article fields should be persisted from auto generation
+        self.article.refresh_from_db()
+        self.assertEqual(self.article.voice_id, "alloy")
+        self.assertEqual(self.article.speed, 1.0)
+        self.assertEqual(
+            self.article.voice_parameters,
+            {
+                "voice_id": "alloy",
+                "speed": 1.0,
+                "affect": "neutral",
+                "tone": "informative",
+            },
+        )

--- a/text_to_audio/services/voice_configuration.py
+++ b/text_to_audio/services/voice_configuration.py
@@ -196,13 +196,18 @@ class VoiceConfigurationService:
             )
 
             # Generate enhanced TTS prompt if needed
+            update_fields = ["voice_id", "speed", "voice_parameters", "detected_genre"]
+
             if voice_parameters:
                 enhanced_prompt = self.voice_parameter_service.generate_enhanced_prompt(
                     voice_parameters
                 )
-                if enhanced_prompt:
+                if enhanced_prompt and hasattr(article, "prompt"):
                     article.prompt = enhanced_prompt
-                    article.save(update_fields=["prompt"])
+                    update_fields.append("prompt")
+
+            # Persist generated parameters on the article
+            article.save(update_fields=update_fields)
 
         else:
             # Use default tone-based voice mapping

--- a/text_to_audio/services/voice_parameter_generation.py
+++ b/text_to_audio/services/voice_parameter_generation.py
@@ -81,6 +81,16 @@ class VoiceParameterGenerationService:
         if "speed" in voice_parameters:
             article.speed = voice_parameters["speed"]
 
+        # Persist generated parameters on the article
+        article.save(
+            update_fields=[
+                "detected_genre",
+                "voice_parameters",
+                "voice_id",
+                "speed",
+            ]
+        )
+
         # Return the complete parameters
         return voice_parameters
 


### PR DESCRIPTION
### **User description**
## Summary
- ensure auto voice parameters are stored on the article
- save article fields after generating parameters
- add regression test for auto voice persistence

## Testing
- `pre-commit run --files text_to_audio/services/voice_configuration.py text_to_audio/services/voice_parameter_generation.py tests/test_auto_voice.py`
- `python run_all_tests_with_mock.py` *(fails: maximum recursion depth exceeded, missing dependencies)*


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Persist auto-generated voice parameters on article

- Accumulate and save updated fields in configure_article_voice

- Automatically save article in generate_voice_parameters

- Enhance tests to assert persistence of voice parameters


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_auto_voice.py</strong><dd><code>Enhance tests for voice parameter persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_auto_voice.py

<li>Reformat long test strings as concatenated literals<br> <li> Mock generate_voice_parameters with side_effect function<br> <li> Add assertions for persisted voice fields after refresh<br> <li> Add <code># noqa: D202</code> to docstring


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/112/files#diff-610948995c6c662ec4d55552c07a3dd11f448d5c0c6e96881020dadcbc6d5f12">+52/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>voice_configuration.py</strong><dd><code>Persist auto voice configuration on article</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/services/voice_configuration.py

<li>Initialize <code>update_fields</code> list with voice fields<br> <li> Append <code>prompt</code> to update_fields if enhanced_prompt present<br> <li> Save article with <code>update_fields</code> after auto generation<br> <li> Ensure newline at end of file


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/112/files#diff-da1f4481d0527d662e628d7e870fe55822f6d36796028db2fe565ad6321f944a">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>voice_parameter_generation.py</strong><dd><code>Auto-save generated voice parameters to article</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/services/voice_parameter_generation.py

<li>Save article after setting <code>voice_id</code>, <code>speed</code>, and parameters<br> <li> Use <code>update_fields</code> to persist genre and voice settings


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/112/files#diff-66a3392336d2ddb5cd45bc7e04120b7279754e10b54b94dd787efc3d58449bac">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>