### PR TITLE
Add inline audio playback to article list

### DIFF
--- a/text_to_audio/templates/article_list.html
+++ b/text_to_audio/templates/article_list.html
@@ -116,6 +116,12 @@
                                         </svg>
                                         Download MP3
                                     </a>
+                                    <button type="button" class="btn btn-success btn-sm play-audio-btn" data-audio-url="{% url 'article-media' article.audio_uuid %}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-circle" viewBox="0 0 16 16">
+                                            <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+                                            <path d="M6.271 5.055a.5.5 0 0 1 .52.038l3.5 2.5a.5.5 0 0 1 0 .814l-3.5 2.5A.5.5 0 0 1 6 10.5v-5a.5.5 0 0 1 .271-.445z"/>
+                                        </svg> Play
+                                    </button>
                                     <a href="{% url 'article_voice_settings' article.id %}" class="btn btn-info btn-sm">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-mic" viewBox="0 0 16 16">
                                             <path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5z"/>
@@ -221,10 +227,39 @@
         </div>
     {% endif %}
 </div>
+
+<audio id="audioPlayer" controls style="width: 100%; margin-top: 20px; display: none;"></audio>
+
 {% endblock %}
 
 {% block extra_js %}
 <script>
+const audioPlayer = document.getElementById('audioPlayer');
+const playButtons = document.querySelectorAll('.play-audio-btn');
+
+function attachPlayButtonListeners() {
+    const currentPlayButtons = document.querySelectorAll('.play-audio-btn');
+    currentPlayButtons.forEach(button => {
+        // Remove existing listener to avoid duplicates if this function is called multiple times
+        button.removeEventListener('click', handlePlayButtonClick);
+        button.addEventListener('click', handlePlayButtonClick);
+    });
+}
+
+function handlePlayButtonClick(event) {
+    event.preventDefault();
+    const audioUrl = event.currentTarget.dataset.audioUrl;
+    if (audioPlayer.src !== audioUrl) {
+        audioPlayer.src = audioUrl;
+    }
+    audioPlayer.style.display = 'block'; // Show the player
+    audioPlayer.play();
+}
+
+// Initial attachment of listeners
+attachPlayButtonListeners();
+
+
 function copyFeedUrl() {
     var copyText = document.getElementById("feed-url");
     copyText.select();
@@ -268,7 +303,49 @@ function updateArticleStatus() {
                     if (a.status === 'COMPLETED') {
                         const actions = row.querySelector('.action-cell');
                         if (actions) {
-                            actions.innerHTML = `<a href="/audio/${a.audio_uuid}/" class="btn btn-primary btn-sm">Download MP3</a>`;
+                            // Check if the play button already exists
+                            if (!actions.querySelector('.play-audio-btn')) {
+                                actions.innerHTML = `
+                                <a href="/audio/${a.audio_uuid}/" class="btn btn-primary btn-sm">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-download" viewBox="0 0 16 16">
+                                        <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
+                                        <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>
+                                    </svg>
+                                    Download MP3
+                                </a>
+                                <button type="button" class="btn btn-success btn-sm play-audio-btn" data-audio-url="/audio/${a.audio_uuid}/">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-circle" viewBox="0 0 16 16">
+                                        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+                                        <path d="M6.271 5.055a.5.5 0 0 1 .52.038l3.5 2.5a.5.5 0 0 1 0 .814l-3.5 2.5A.5.5 0 0 1 6 10.5v-5a.5.5 0 0 1 .271-.445z"/>
+                                    </svg> Play
+                                </button>
+                                <a href="/article/${a.id}/voice-settings/" class="btn btn-info btn-sm">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-mic" viewBox="0 0 16 16">
+                                        <path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5z"/>
+                                        <path d="M10 8a2 2 0 1 1-4 0V3a2 2 0 1 1 4 0v5zM8 0a3 3 0 0 0-3 3v5a3 3 0 0 0 6 0V3a3 3 0 0 0-3-3z"/>
+                                    </svg>
+                                    Voice Settings
+                                </a>
+                                <form method="post" action="/article/${a.id}/regenerate/" class="d-inline">
+                                    {% csrf_token %}
+                                    <button type="submit" class="btn btn-outline-secondary btn-sm">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/>
+                                            <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>
+                                        </svg>
+                                        Regenerate
+                                    </button>
+                                </form>
+                                <a href="/feed/{{ article.feed.id }}/article/${a.id}/delete/" class="btn btn-danger btn-sm">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+                                        <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+                                        <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+                                    </svg>
+                                    Delete
+                                </a>`;
+                                // Re-attach event listeners for newly created play buttons
+                                attachPlayButtonListeners();
+                            }
                         }
                     }
                 }
@@ -278,5 +355,37 @@ function updateArticleStatus() {
 }
 setInterval(updateArticleStatus, 10000);
 {% endif %}
+
+// Ensure listeners are re-attached if articles are dynamically updated
+// by observing the table body for changes.
+const articleTableBody = document.querySelector('.table-responsive tbody');
+if (articleTableBody) {
+    const observer = new MutationObserver(mutations => {
+        mutations.forEach(mutation => {
+            if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+                // Check if new rows were added or existing rows' action cells were updated
+                let needsReAttach = false;
+                mutation.addedNodes.forEach(node => {
+                    if (node.nodeType === Node.ELEMENT_NODE && node.tagName === 'TR') {
+                        if (node.querySelector('.play-audio-btn')) {
+                            needsReAttach = true;
+                        }
+                    }
+                });
+                // Also check if an existing row's actions were updated
+                if (!needsReAttach && mutation.target && mutation.target.classList && mutation.target.classList.contains('action-cell')) {
+                     if (mutation.target.querySelector('.play-audio-btn')) {
+                        needsReAttach = true;
+                     }
+                }
+
+                if (needsReAttach) {
+                    attachPlayButtonListeners();
+                }
+            }
+        });
+    });
+    observer.observe(articleTableBody, { childList: true, subtree: true });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
This feature allows you to play the audio of articles directly from the feed's article list page without needing to download the MP3 file first.

Key changes:
- Added a "Play" button to each completed article in `text_to_audio/templates/article_list.html`.
- Included a single shared HTML5 `<audio>` player on the page.
- Implemented JavaScript to handle "Play" button clicks:
    - Sets the audio player's source to the respective article's audio URL.
    - Manages playback (plays the selected audio, stopping any previously playing audio).
    - The audio player is initially hidden and becomes visible when playback starts.
- Ensured that dynamically updated articles (e.g., when status changes from processing to completed) also get a functional "Play" button. This is handled by re-attaching event listeners after DOM updates and using a MutationObserver for robustness.
- Styling for the new button and player leverages existing Bootstrap classes and required no additional CSS.
- Code-based testing indicates the functionality should work as expected.