### PR TITLE
Here's a revised message that addresses the article processing timeou…

### DIFF
--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -1590,3 +1590,122 @@ class SpeedClampingUnitTests(TestCase):
 
 
 # To run these tests: python manage.py test text_to_audio.tests.test_tasks
+
+
+from datetime import timedelta
+
+from django.utils import timezone
+from django.conf import settings as django_settings
+
+from text_to_audio.tasks import check_stale_articles
+
+
+class CheckStaleArticlesTests(TestCase):
+    """Tests for the check_stale_articles task."""
+
+    def setUp(self):
+        """Set up test data and environment for each test."""
+        self.user = User.objects.create_user(
+            username="staletestuser", password="password"
+        )
+        self.feed = Feed.objects.create(user=self.user, name="Stale Test Feed")
+
+        # Mock ARTICLE_PROCESSING_TIMEOUT_SECONDS
+        self.mock_timeout_seconds = 60
+        self.settings_patcher = patch.object(
+            django_settings,
+            "ARTICLE_PROCESSING_TIMEOUT_SECONDS",
+            self.mock_timeout_seconds,
+        )
+        self.settings_patcher.start()
+
+        # Mock celery app control revoke
+        self.revoke_patcher = patch("rss_tts.celery.app.control.revoke")
+        self.mock_revoke = self.revoke_patcher.start()
+
+    def tearDown(self):
+        """Clean up after each test."""
+        self.settings_patcher.stop()
+        self.revoke_patcher.stop()
+        # Clean up any created articles, feeds, users if necessary
+        Article.objects.all().delete()
+        Feed.objects.filter(user=self.user).delete()
+        self.user.delete()
+
+
+    def test_check_stale_articles_logic(self):
+        """Test that stale articles are correctly identified and processed."""
+        now = timezone.now()
+        very_old_time = now - timedelta(seconds=self.mock_timeout_seconds * 2)
+        recent_time = now - timedelta(seconds=self.mock_timeout_seconds // 2)
+
+        stale_article = Article.objects.create(
+            feed=self.feed,
+            title="Stale Article",
+            text_content="This article should time out.",
+            status=Article.PROCESSING,
+            celery_task_id="fake_stale_task_id",
+            updated_at=very_old_time,
+        )
+        # Manually set updated_at as save() would update it
+        Article.objects.filter(pk=stale_article.pk).update(updated_at=very_old_time)
+        stale_article.refresh_from_db()
+
+
+        recent_processing_article = Article.objects.create(
+            feed=self.feed,
+            title="Recent Processing Article",
+            text_content="This article is still processing.",
+            status=Article.PROCESSING,
+            celery_task_id="fake_recent_task_id",
+            updated_at=recent_time,
+        )
+        Article.objects.filter(pk=recent_processing_article.pk).update(updated_at=recent_time)
+        recent_processing_article.refresh_from_db()
+
+        completed_article = Article.objects.create(
+            feed=self.feed,
+            title="Completed Article",
+            text_content="This article is completed.",
+            status=Article.COMPLETED,
+            updated_at=very_old_time, # old but completed
+        )
+        Article.objects.filter(pk=completed_article.pk).update(updated_at=very_old_time)
+        completed_article.refresh_from_db()
+
+        failed_article_already = Article.objects.create(
+            feed=self.feed,
+            title="Already Failed Article",
+            text_content="This article already failed.",
+            status=Article.FAILED,
+            updated_at=very_old_time, # old but already failed
+        )
+        Article.objects.filter(pk=failed_article_already.pk).update(updated_at=very_old_time)
+        failed_article_already.refresh_from_db()
+
+        # Call the task
+        check_stale_articles()
+
+        # Refresh articles from DB
+        stale_article.refresh_from_db()
+        recent_processing_article.refresh_from_db()
+        completed_article.refresh_from_db()
+        failed_article_already.refresh_from_db()
+
+        # Assertions for stale_article
+        self.assertEqual(stale_article.status, Article.FAILED)
+        self.assertIn("timed out", stale_article.error_message.lower())
+        self.assertIsNone(stale_article.celery_task_id)
+        self.mock_revoke.assert_called_once_with(
+            "fake_stale_task_id", terminate=True
+        )
+
+        # Assertions for recent_processing_article
+        self.assertEqual(recent_processing_article.status, Article.PROCESSING)
+        self.assertIsNone(recent_processing_article.error_message) # Should not have error
+
+        # Assertions for completed_article
+        self.assertEqual(completed_article.status, Article.COMPLETED)
+
+        # Assertions for failed_article_already
+        self.assertEqual(failed_article_already.status, Article.FAILED)

--- a/text_to_audio/admin.py
+++ b/text_to_audio/admin.py
@@ -23,7 +23,7 @@ class FeedAdmin(admin.ModelAdmin):
 class ArticleAdmin(admin.ModelAdmin):
     """Admin interface for the Article model."""
 
-    list_display = ["title", "feed", "status", "created_at"]
-    list_filter = ["status", "created_at", "feed"]
+    list_display = ["title", "feed", "status", "created_at", "updated_at"]
+    list_filter = ["status", "created_at", "updated_at", "feed"]
     search_fields = ["title", "feed__name", "feed__user__username"]
-    readonly_fields = ["created_at", "prompt"]
+    readonly_fields = ["created_at", "updated_at", "prompt"]


### PR DESCRIPTION
### **User description**
…t mechanism:

This commit addresses concerns about articles getting stuck in a processing state.

Key findings and changes:

1.  An existing scheduled task is responsible for timing out articles stuck in processing. This task runs periodically and uses a configurable timeout setting.
2.  I verified that the configurations for the timeout duration and the schedule are appropriate.
3.  I confirmed that the way the `Article` model tracks updates supports this timeout logic.
4.  I added a new set of tests to ensure the scheduled task correctly marks stale articles as FAILED, attempts to cancel their associated operations, and leaves non-stale articles unaffected. This provides assurance that scenarios like server reboots are handled.
5.  I updated the administrative interface to ensure creation and update timestamps are consistently displayed and filterable, improving visibility for administrators.

The existing timeout mechanism, now with enhanced testing, should correctly handle articles that are stuck or interrupted during processing. Please ensure that the scheduled task service is running in your environment for this feature to function.


___

### **PR Type**
Tests, Enhancement


___

### **Description**
Add CheckStaleArticlesTests unit tests
Mock timeout and revoke in stale tests
Verify stale articles fail and cancel tasks
Enhance ArticleAdmin with updated_at display


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_tasks.py</strong><dd><code>Add tests for check_stale_articles task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/text_to_audio/test_tasks.py

<li>Introduce CheckStaleArticlesTests for stale cleanup<br> <li> Mock ARTICLE_PROCESSING_TIMEOUT_SECONDS setting<br> <li> Patch celery revoke control for task revocation<br> <li> Assert statuses and error messages correctly


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/127/files#diff-92b9935e180b5c885c30de11967e5900573cb0a2eef0b8581615d4224a58d18a">+119/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin.py</strong><dd><code>Include updated_at in ArticleAdmin display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/admin.py

<li>Add updated_at to list_display and list_filter<br> <li> Include updated_at in readonly_fields<br> <li> Improve admin visibility for article timestamps


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/127/files#diff-5e837ecdcc339a610ad162df67a336a3aff2190e200259837eda991ab4b95948">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>