### PR TITLE
Add gh cli tool to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,6 +31,16 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Install GitHub CLI
+RUN (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt update \
+    && apt install gh -y
+
 # Install pip and dev tools
 RUN pip install --upgrade pip \
     && pip install pre-commit black flake8 mypy isort pytest pytest-django

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI
-RUN (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
+RUN (type -p wget >/dev/null || (apt-get update && apt-get install wget -y)) \
     && mkdir -p -m 755 /etc/apt/keyrings \
     && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,7 @@ RUN (type -p wget >/dev/null || (apt-get update && apt-get install wget -y)) \
     && mkdir -p -m 755 /etc/apt/keyrings \
     && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && rm -f $out \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt update \


### PR DESCRIPTION
### **User description**
This pull request updates the `.devcontainer/Dockerfile` to include the installation of the GitHub CLI (`gh`). This addition ensures that the development container has the necessary tools for interacting with GitHub directly from the command line.

Key change:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R34-R43): Added a series of commands to install the GitHub CLI (`gh`) using `wget` to fetch the keyring, configure the repository, and install the package. This enhances the container's functionality for GitHub-related tasks.


___

### **PR Type**
Enhancement


___

### **Description**
- Add GitHub CLI installation in devcontainer Dockerfile

- Ensure wget availability for CLI download

- Configure GPG keyring and apt repository

- Install `gh` package


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add GitHub CLI installation steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/Dockerfile

<li>Insert RUN block to install GitHub CLI (<code>gh</code>)<br> <li> Conditionally install <code>wget</code> if missing<br> <li> Create and secure /etc/apt/keyrings<br> <li> Add GitHub CLI apt repository and install


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/128/files#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>