### PR TITLE
feat: add single-voice mode with text normalization for voice presets

### DIFF
--- a/text_to_audio/services/chunk_tone_service.py
+++ b/text_to_audio/services/chunk_tone_service.py
@@ -69,6 +69,82 @@ class ChunkToneService:
                 )
                 return self.create_fallback_payload(text)
 
+    def get_single_voice_payload(
+        self,
+        text: str,
+        title: str,
+        max_chars: int,
+        voice: str,
+        character_name: str = "narrator",
+    ) -> ChunkTonePayload:
+        """
+        Generate ChunkTonePayload for single-voice mode with text normalization.
+
+        This is used when a user has selected a voice preset - we disable multi-voice
+        and only use their chosen voice, but still chunk intelligently and normalize
+        text for better TTS output.
+
+        Args:
+            text: The text content to analyze and chunk
+            title: The article title for context
+            max_chars: Maximum characters per chunk
+            voice: The voice to use for all chunks
+            character_name: The character name to use (default: "narrator")
+
+        Returns:
+            ChunkTonePayload with all chunks using the same voice
+        """
+        prompt = self._build_single_voice_prompt(text, title, max_chars, voice)
+
+        # First attempt
+        try:
+            response_json = self._call_openai(prompt)
+            # Override any voice assignments from LLM with the preset voice
+            if "chunks" in response_json:
+                for chunk in response_json["chunks"]:
+                    chunk["voice"] = {"voice": voice}
+                    chunk["character_name"] = character_name
+            return ChunkTonePayload.model_validate(response_json)
+        except (ValidationError, Exception) as e:
+            logger.warning(f"First attempt failed for single-voice mode: {e}")
+
+            # Retry attempt
+            try:
+                response_json = self._call_openai(prompt)
+                # Override any voice assignments from LLM with the preset voice
+                if "chunks" in response_json:
+                    for chunk in response_json["chunks"]:
+                        chunk["voice"] = {"voice": voice}
+                        chunk["character_name"] = character_name
+                return ChunkTonePayload.model_validate(response_json)
+            except (ValidationError, Exception) as e2:
+                logger.error(
+                    f"Second attempt failed for single-voice mode: {e2}. Using fallback."
+                )
+                return self.create_single_voice_fallback(text, voice)
+
+    def create_single_voice_fallback(self, text: str, voice: str) -> ChunkTonePayload:
+        """
+        Create a fallback payload with specified voice when LLM processing fails.
+
+        Args:
+            text: The text content to create fallback for
+            voice: The voice to use
+
+        Returns:
+            ChunkTonePayload with single specified voice
+        """
+        return ChunkTonePayload(
+            chunks=[
+                ChunkData(
+                    text=text,
+                    voice=TTSVoice(voice=voice),
+                    character_name="narrator",
+                    instructions="Speak in a clear, engaging manner with appropriate expression for the content.",
+                )
+            ]
+        )
+
     def create_fallback_payload(self, text: str) -> ChunkTonePayload:
         """
         Create a fallback payload with narrator voice when LLM processing fails.
@@ -127,6 +203,48 @@ Example instructions:
 - "Use dramatic emphasis. Varied pacing to build tension. Dynamic pitch variation for engagement."
 
 The JSON must be valid and parseable. Do not include any other text or explanations."""
+
+    def _build_single_voice_prompt(
+        self, text: str, title: str, max_chars: int, voice: str
+    ) -> str:
+        """Build the prompt for single-voice mode with text normalization."""
+        return f"""You are a text-to-speech preprocessing specialist. Prepare the following article for TTS by:
+
+1. Breaking it into logical chunks (maximum {max_chars} characters each)
+2. Expanding ALL abbreviations for natural speech
+3. Converting dates and numbers to spoken form
+4. Maintaining the original meaning while optimizing for speech
+
+Article Title: {title}
+
+Article Text:
+{text}
+
+Text Normalization Rules:
+- Expand state abbreviations: VA → Virginia, CA → California, NY → New York, etc.
+- Expand titles: Mr. → Mister, Mrs. → Missus, Dr. → Doctor, Prof. → Professor, etc.
+- Expand common abbreviations: St. → Street, Ave. → Avenue, Co. → Company, Inc. → Incorporated, etc.
+- Convert dates: 1/1/2000 → January first, two thousand; 12/25/2025 → December twenty-fifth, twenty twenty-five
+- Convert times: 3:30 PM → three thirty P M, 9:00 AM → nine o'clock A M
+- Spell out numbers in context: "5 people" → "five people", "$100" → "one hundred dollars"
+- Expand units: kg → kilograms, mi → miles, ft → feet, etc.
+- Handle special cases: U.S. → United States, U.K. → United Kingdom, E.U. → European Union
+
+Return ONLY a JSON object with this exact structure:
+{{
+  "chunks": [
+    {{
+      "text": "normalized chunk text here with all abbreviations expanded",
+      "voice": {{"voice": "{voice}"}},
+      "character_name": "narrator",
+      "instructions": "Detailed TTS instructions for tone and pacing"
+    }}
+  ]
+}}
+
+IMPORTANT: All chunks must use voice "{voice}" and character_name "narrator".
+The text in each chunk should have ALL abbreviations and numbers expanded for natural speech.
+Break at natural pauses like paragraphs or sentence boundaries when possible."""
 
     def _call_openai(self, prompt: str) -> dict:
         """

--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -555,12 +555,27 @@ def process_article(self, article_id: int) -> str:
                 if article.title:
                     text_for_chunking = f"{article.title}.\n\n{article.text_content}"
 
-                # Get chunks from LLM service
-                chunk_tone_payload = chunk_tone_service.get_payload(
-                    text=text_for_chunking,
-                    title=article.title or "Untitled",
-                    max_chars=4000,
-                )
+                # Check if article has a voice preset (user explicitly selected a voice)
+                if article.voice_preset:
+                    logger.info(
+                        f"Article {article_id} has voice preset '{article.voice_preset.name}'. "
+                        f"Using single-voice mode with text normalization."
+                    )
+                    # Use single-voice mode with the preset voice
+                    preset_voice = article.voice_preset.voice_id
+                    chunk_tone_payload = chunk_tone_service.get_single_voice_payload(
+                        text=text_for_chunking,
+                        title=article.title or "Untitled",
+                        max_chars=4000,
+                        voice=preset_voice,
+                    )
+                else:
+                    # Use normal multi-voice mode
+                    chunk_tone_payload = chunk_tone_service.get_payload(
+                        text=text_for_chunking,
+                        title=article.title or "Untitled",
+                        max_chars=4000,
+                    )
 
                 logger.info(
                     f"ChunkToneService returned {len(chunk_tone_payload.chunks)} chunks for Article ID: {article_id}"
@@ -725,8 +740,10 @@ def process_article(self, article_id: int) -> str:
 
         # --- Legacy Multi-Voice TTS Generation Attempt ---
         multi_voice_generation_successful = False
-        if not chunk_tone_generation_successful and _is_valid_multi_voice_data(
-            article.multi_voice_data
+        if (
+            not chunk_tone_generation_successful
+            and _is_valid_multi_voice_data(article.multi_voice_data)
+            and not article.voice_preset  # Skip multi-voice if preset is selected
         ):
             try:
                 logger.info(
@@ -946,9 +963,16 @@ def process_article(self, article_id: int) -> str:
                     False  # Ensure fallback is triggered
                 )
         else:
-            logger.info(
-                f"Skipping multi-voice generation for Article ID: {article_id} due to missing or invalid multi_voice_data."
-            )
+            if article.voice_preset:
+                logger.info(
+                    f"Skipping multi-voice generation for Article ID: {article_id} "
+                    f"because voice preset '{article.voice_preset.name}' is selected."
+                )
+            else:
+                logger.info(
+                    f"Skipping multi-voice generation for Article ID: {article_id} "
+                    f"due to missing or invalid multi_voice_data."
+                )
 
         # --- Fallback to Single-Voice Generation ---
         if (


### PR DESCRIPTION
### **User description**
This pull request introduces support for single-voice mode in text-to-speech (TTS) processing, allowing users to select a specific voice preset for articles. The changes include methods for handling single-voice payload generation, updates to the prompt-building logic, and modifications to the article processing flow to prioritize voice presets when available.

### Single-Voice Mode Implementation:

* **`text_to_audio/services/chunk_tone_service.py`:** Added the `get_single_voice_payload` method to generate TTS payloads using a single voice preset, including retries and fallback logic for failed attempts. Also introduced the `_build_single_voice_prompt` method to construct prompts tailored for single-voice mode with text normalization. [[1]](diffhunk://#diff-2cc5a2e0e61d85a7c98ccd38158495c615ceae6f40051dbf2301ca855871ba43R72-R147) [[2]](diffhunk://#diff-2cc5a2e0e61d85a7c98ccd38158495c615ceae6f40051dbf2301ca855871ba43R207-R248)

### Article Processing Updates:

* **`text_to_audio/tasks.py`:** Modified the `process_article` method to check for voice presets and use single-voice mode when a preset is selected. Added logic to skip multi-voice generation if a voice preset is specified. [[1]](diffhunk://#diff-de8add76ee05b0f2966a00749cedd86824b9d710327aa1c48d56844b35e4ee70L558-R573) [[2]](diffhunk://#diff-de8add76ee05b0f2966a00749cedd86824b9d710327aa1c48d56844b35e4ee70L728-R746) [[3]](diffhunk://#diff-de8add76ee05b0f2966a00749cedd86824b9d710327aa1c48d56844b35e4ee70R965-R974)


___

### **PR Type**
Enhancement


___

### **Description**
- Implement single-voice TTS mode with normalization

- Introduce get_single_voice_payload with retry logic

- Add prompt builder for text normalization chunks

- Update process_article to use voice presets


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chunk_tone_service.py</strong><dd><code>Support single-voice TTS payload generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/services/chunk_tone_service.py

<li>Added get_single_voice_payload method for single-voice mode<br> <li> Implemented retry logic and override of chunk voices<br> <li> Created create_single_voice_fallback for error handling<br> <li> Introduced _build_single_voice_prompt for normalization


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/129/files#diff-2cc5a2e0e61d85a7c98ccd38158495c615ceae6f40051dbf2301ca855871ba43">+118/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.py</strong><dd><code>Integrate single-voice mode into article processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/tasks.py

<li>Check voice_preset and call get_single_voice_payload<br> <li> Skip multi-voice generation when preset is selected<br> <li> Updated logging for preset-based processing paths


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/129/files#diff-de8add76ee05b0f2966a00749cedd86824b9d710327aa1c48d56844b35e4ee70">+35/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>