### PR TITLE
Fix file upload field

### DIFF
--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -93,6 +93,14 @@ class TestArticleSubmission(TestCase):
         self.assertEqual(follow_response.status_code, 200)
         self.assertTemplateUsed(follow_response, "article_form.html")
 
+    def test_article_form_has_file_upload(self):
+        """Article submission form should include a file upload field."""
+        self.client.login(username="tester", password="pass123")
+        response = self.client.get(f"/feeds/{self.feed.pk}/add/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'enctype="multipart/form-data"')
+        self.assertContains(response, 'name="document_file"')
+
     def test_post_creates_article(self):
         """Test that submitting the article form creates a new article."""
         self.client.login(username="tester", password="pass123")

--- a/text_to_audio/templates/article_form.html
+++ b/text_to_audio/templates/article_form.html
@@ -40,7 +40,7 @@
         </div>
         {% endif %}
 
-        <form method="post">
+        <form method="post" enctype="multipart/form-data">
           {% csrf_token %}
 
           <div class="mb-3">
@@ -62,6 +62,15 @@
             {{ form.text_content.errors }}
             {{ form.text_content|add_class:"form-control" }}
             <div class="form-text">Or paste/enter text content directly</div>
+          </div>
+
+          <div class="mb-3">
+            <label for="{{ form.document_file.id_for_label }}" class="form-label">{{ form.document_file.label }}</label>
+            {{ form.document_file.errors }}
+            {{ form.document_file|add_class:"form-control" }}
+            {% if form.document_file.help_text %}
+            <div class="form-text">{{ form.document_file.help_text }}</div>
+            {% endif %}
           </div>
 
           <h5 class="mt-4 mb-3">Voice Settings</h5>


### PR DESCRIPTION
## Summary
- add enctype and document_file field to article form
- test presence of file upload

## Testing
- `python run_all_tests_with_mock.py` *(fails: ImportError: cannot import name 'field_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68436fedd3ac8326a6d7029104bdee61