### PR TITLE
fix: prevent URL reversal error for media URLs

### DIFF
--- a/text_to_audio/templates/article_list.html
+++ b/text_to_audio/templates/article_list.html
@@ -262,7 +262,9 @@ const playIconSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="
 const pauseIconSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pause-circle" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="M5 6.25a1.25 1.25 0 1 1 2.5 0v3.5a1.25 1.25 0 1 1-2.5 0v-3.5zm3.5 0a1.25 1.25 0 1 1 2.5 0v3.5a1.25 1.25 0 1 1-2.5 0v-3.5z"/></svg> Pause';
 
 // Create URL template patterns - these are processed server-side during initial page render
-const mediaUrlTemplate = '{% url "article-media" 0 %}'.replace('/0/', '/');
+// Use a valid UUID placeholder so Django can reverse the URL
+const mediaUrlTemplate = '{% url "article-media" "00000000-0000-0000-0000-000000000000" %}'
+    .replace('00000000-0000-0000-0000-000000000000/', '');
 const voiceSettingsUrlTemplate = '{% url "article_voice_settings" 0 %}'.replace('/0/', '/');
 const regenerateUrlTemplate = '{% url "article-regenerate" 0 %}'.replace('/0/', '/');
 {% if feed %}


### PR DESCRIPTION
### **User description**
## Summary
- generate JavaScript media URL template using a valid UUID placeholder

## Testing
- `pre-commit run --files text_to_audio/templates/article_list.html`
- `python run_all_tests_with_mock.py` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_684376b9b8e48326944e92bb912c465e


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes URL reversal error for media URLs in template

- Uses valid UUID placeholder in `mediaUrlTemplate` JavaScript variable

- Ensures Django URL reversing works without errors


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>article_list.html</strong><dd><code>Use UUID placeholder for Django media URL reversal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/templates/article_list.html

<li>Replaces integer placeholder with UUID in <code>mediaUrlTemplate</code><br> <li> Updates JavaScript to use valid UUID for Django URL reversal<br> <li> Removes trailing slash from generated URL template


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/132/files#diff-e50328adcce791cd2d453424bf79ca870d497a43a9293b092391c49aaaab8e22">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>