### PR TITLE
Ignore E501 in chunk tone service

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ per-file-ignores =
     tests/text_to_audio/test_views_followed_feed.py:E501,F841
     text_to_audio/forms.py:E501
     text_to_audio/services/genre_classification.py:E501
+    text_to_audio/services/chunk_tone_service.py:E501
     text_to_audio/services/user_preferences.py:E501,C901
     text_to_audio/services/voice_configuration.py:C901
     text_to_audio/services/voice_parameter_generation.py:C901


### PR DESCRIPTION
### **User description**
## Summary
- ignore line length warnings in `chunk_tone_service.py`

## Testing
- `pre-commit run --files setup.cfg text_to_audio/services/chunk_tone_service.py --hook-stage push`
- `python run_all_tests_with_mock.py` *(fails: ImportError: cannot import name 'field_validator' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6843795ca818832680be6ce8d11a50c4


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Exempted `chunk_tone_service.py` from E501 line length checks

- Updated `setup.cfg` per-file-ignores for code style consistency


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.cfg</strong><dd><code>Ignore E501 line length in chunk_tone_service.py via setup.cfg</code></dd></summary>
<hr>

setup.cfg

<li>Added <code>text_to_audio/services/chunk_tone_service.py:E501</code> to <br>per-file-ignores<br> <li> Ensures line length warnings (E501) are ignored for this file


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/137/files#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>