### PR TITLE
Clarify abbreviation handling

### DIFF
--- a/tests/text_to_audio/test_chunk_tone_service.py
+++ b/tests/text_to_audio/test_chunk_tone_service.py
@@ -289,3 +289,9 @@ class TestChunkToneService:
         # Empty chunks should fail validation
         with pytest.raises(ValidationError):
             ChunkTonePayload(chunks=[])
+
+    def test_single_voice_prompt_respects_letter_abbreviations(self, service):
+        """Ensure single-voice prompt keeps letter-by-letter abbreviations."""
+        prompt = service._build_single_voice_prompt("Text", "Title", 1000, "alloy")
+        assert "spoken as words" in prompt
+        assert "letter by letter" in prompt

--- a/text_to_audio/services/chunk_tone_service.py
+++ b/text_to_audio/services/chunk_tone_service.py
@@ -211,7 +211,7 @@ The JSON must be valid and parseable. Do not include any other text or explanati
         return f"""You are a text-to-speech preprocessing specialist. Prepare the following article for TTS by:
 
 1. Breaking it into logical chunks (maximum {max_chars} characters each)
-2. Expanding ALL abbreviations for natural speech
+2. Expanding abbreviations that are normally spoken as words for natural speech
 3. Converting dates and numbers to spoken form
 4. Maintaining the original meaning while optimizing for speech
 
@@ -224,6 +224,7 @@ Text Normalization Rules:
 - Expand state abbreviations: VA → Virginia, CA → California, NY → New York, etc.
 - Expand titles: Mr. → Mister, Mrs. → Missus, Dr. → Doctor, Prof. → Professor, etc.
 - Expand common abbreviations: St. → Street, Ave. → Avenue, Co. → Company, Inc. → Incorporated, etc.
+- Keep abbreviations that are typically spoken letter by letter (e.g., AI, GPT, CPU) as-is.
 - Convert dates: 1/1/2000 → January first, two thousand; 12/25/2025 → December twenty-fifth, twenty twenty-five
 - Convert times: 3:30 PM → three thirty P M, 9:00 AM → nine o'clock A M
 - Spell out numbers in context: "5 people" → "five people", "$100" → "one hundred dollars"
@@ -243,7 +244,7 @@ Return ONLY a JSON object with this exact structure:
 }}
 
 IMPORTANT: All chunks must use voice "{voice}" and character_name "narrator".
-The text in each chunk should have ALL abbreviations and numbers expanded for natural speech.
+The text in each chunk should expand abbreviations normally spoken as words while leaving letter-by-letter abbreviations unchanged. Numbers should be converted to spoken form.
 Break at natural pauses like paragraphs or sentence boundaries when possible."""
 
     def _call_openai(self, prompt: str) -> dict:


### PR DESCRIPTION
### **User description**
## Summary
- specify that chunk tone service only expands abbreviations normally spoken as words
- keep letter-by-letter abbreviations in the TTS output
- test single voice prompt text includes new guidance

## Testing
- `pre-commit run --files text_to_audio/services/chunk_tone_service.py tests/text_to_audio/test_chunk_tone_service.py`
- `python run_single_test.py tests/text_to_audio/test_chunk_tone_service.py`

------
https://chatgpt.com/codex/tasks/task_e_684cb124c0348326855ab953d5ed578b


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refine single-voice prompt abbreviation rules

- Keep letter-by-letter abbreviations unchanged

- Update prompt docstring with new guidance

- Add test for letter-by-letter abbreviation retention


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chunk_tone_service.py</strong><dd><code>clarify abbreviation expansion rules in prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/services/chunk_tone_service.py

<li>Updated step 2 to expand only word-like abbreviations<br> <li> Added rule to keep AI, GPT, CPU as-is<br> <li> Amended final instruction to reflect new abbreviation guidance


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/140/files#diff-2cc5a2e0e61d85a7c98ccd38158495c615ceae6f40051dbf2301ca855871ba43">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_chunk_tone_service.py</strong><dd><code>add test for letter-by-letter abbreviations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/text_to_audio/test_chunk_tone_service.py

<li>Introduced test_single_voice_prompt_respects_letter_abbreviations<br> <li> Validates prompt contains both "spoken as words" and "letter by <br>letter"


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/140/files#diff-dd4ea76a9cfc103a857c9e1750282558ebf506140f7a5383f849c7afaccd7f72">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>