### PR TITLE
Add trailing silence to audio

### DIFF
--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -287,10 +287,11 @@ class ProcessArticleTests(TestCase):
         if TEST_MEDIA_ROOT.exists():
             shutil.rmtree(TEST_MEDIA_ROOT)
 
+    @patch("text_to_audio.tasks.AudioSegment.silent")
     @patch("text_to_audio.tasks.AudioSegment.from_mp3")
     @patch("text_to_audio.tasks.AudioSegment.empty")
     def test_process_article_success_single_chunk(
-        self, mock_audio_empty, mock_audio_from_mp3, MockOpenAIClient
+        self, mock_audio_empty, mock_audio_from_mp3, mock_silent, MockOpenAIClient
     ):
         """Test that processing an article with a single text chunk works correctly."""
         mock_openai_instance = MockOpenAIClient.return_value
@@ -322,6 +323,7 @@ class ProcessArticleTests(TestCase):
         mock_audio_segment.export.side_effect = export_side_effect
         mock_audio_from_mp3.return_value = mock_audio_segment
         mock_audio_empty.return_value = MagicMock()
+        mock_silent.return_value = MagicMock()
 
         result = process_article(self.article.id)
 
@@ -338,6 +340,7 @@ class ProcessArticleTests(TestCase):
         # Verify the mock calls specific to the new export parameters
         mock_audio_segment.set_frame_rate.assert_called_once_with(44100)
         mock_audio_segment.export.assert_called_once()
+        mock_silent.assert_called_once_with(duration=2000)
         # Verify export parameters (CBR and tags)
         export_call = mock_audio_segment.export.call_args
         self.assertEqual(export_call[1]["bitrate"], "128k")
@@ -467,12 +470,15 @@ class ProcessArticleTests(TestCase):
             "text_to_audio.tasks._legacy_chunk_text"
         ) as mock_legacy_chunk_text, patch(
             "text_to_audio.tasks.AudioSegment"
-        ), patch.object(
+        ) as mock_audio_segment_cls, patch.object(
             Path, "rename"
         ):  # Prevent file rename attempts
 
             # Return 2 chunks to force multi-chunk processing
             mock_legacy_chunk_text.return_value = (True, chunks_data)
+            mock_audio_segment_cls.from_mp3.return_value = MagicMock()
+            mock_audio_segment_cls.empty.return_value = MagicMock()
+            mock_audio_segment_cls.silent.return_value = MagicMock()
 
             # Run the function
             result = process_article(self.article.id)
@@ -502,6 +508,7 @@ class ProcessArticleTests(TestCase):
             self.assertEqual(
                 result, f"Article {self.article.id} processed successfully."
             )
+            mock_audio_segment_cls.silent.assert_called_once_with(duration=2000)
 
     @patch("text_to_audio.tasks.AudioSegment.from_mp3")
     @patch("text_to_audio.tasks.AudioSegment.empty")

--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -32,6 +32,9 @@ from .utils import process_url_to_text
 # Configure logging
 logger = logging.getLogger(__name__)
 
+# Add a short pause to the end of exported audio files
+ENDING_SILENCE_MS = 2000
+
 
 def _clamp_tts_speed(speed: float) -> float:
     """Clamp TTS speed to valid range [0.25, 4.0].
@@ -1186,6 +1189,7 @@ def process_article(self, article_id: int) -> str:
             audio_segment = audio_segment.set_frame_rate(
                 44100
             )  # Ensure consistent frame rate
+            audio_segment += AudioSegment.silent(duration=ENDING_SILENCE_MS)
             audio_segment.export(
                 str(final_audio_path),
                 format="mp3",
@@ -1215,6 +1219,7 @@ def process_article(self, article_id: int) -> str:
                 combined_audio = combined_audio.set_frame_rate(
                     44100
                 )  # Ensure consistent frame rate
+                combined_audio += AudioSegment.silent(duration=ENDING_SILENCE_MS)
                 combined_audio.export(
                     str(final_audio_path),
                     format="mp3",


### PR DESCRIPTION
### **User description**
## Summary
- add `ENDING_SILENCE_MS` constant
- append silence before exporting mp3
- test that silence is appended for single and multi chunk cases

## Testing
- `pre-commit run --files text_to_audio/tasks.py tests/text_to_audio/test_tasks.py` *(fails: unable to fetch pre-commit hooks)*
- `python run_single_test.py tests/text_to_audio/test_tasks.py` *(fails: ImportError from pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68521872d2c483268351fb373697e335


___

### **PR Type**
Enhancement, Tests


___

### **Description**
Append 2s silence to single-chunk exports.
Append 2s silence to multi-chunk exports.
Introduce ENDING_SILENCE_MS constant.
Update tests to mock and assert silence.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tasks.py</strong><dd><code>Add trailing silence in tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/tasks.py

<li>Define <code>ENDING_SILENCE_MS</code> constant (2000ms).<br> <li> Append silence to single-chunk audio before export.<br> <li> Append silence to combined multi-chunk audio before export.


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/141/files#diff-de8add76ee05b0f2966a00749cedd86824b9d710327aa1c48d56844b35e4ee70">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_tasks.py</strong><dd><code>Mock and assert silence in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/text_to_audio/test_tasks.py

<li>Patch <code>AudioSegment.silent</code> in relevant tests.<br> <li> Stub <code>silent</code> return value in audio mocks.<br> <li> Add <code>mock_silent</code> parameter to test signatures.<br> <li> Assert <code>silent</code> called with duration 2000ms.


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/141/files#diff-92b9935e180b5c885c30de11967e5900573cb0a2eef0b8581615d4224a58d18a">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>