### PR TITLE
feat: raise audio output volume

### DIFF
--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -9,6 +9,7 @@ functionality.
 from __future__ import annotations
 
 import shutil
+import math
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -1236,5 +1237,14 @@ class SpeedClampingUnitTests(TestCase):
         self.assertEqual(_clamp_tts_speed(2.5), 2.5)
         self.assertEqual(_clamp_tts_speed(4.0), 4.0)
 
+
+# New tests for volume gain constant
+class VolumeGainConstantTests(TestCase):
+    def test_volume_gain_constant(self):
+        """Ensure volume is increased by about 3dB."""
+        from text_to_audio.tasks import VOLUME_GAIN_DB
+
+        expected_gain = 3.0
+        self.assertAlmostEqual(VOLUME_GAIN_DB, expected_gain, places=2)
 
 # To run these tests: python manage.py test text_to_audio.tests.test_tasks

--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import logging
-import math
 import os
 import time  # Added for timing API calls
 import traceback
@@ -35,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 # Add a short pause to the end of exported audio files
 ENDING_SILENCE_MS = 2000
-VOLUME_GAIN_DB = 20 * math.log10(1.1)  # ~10% volume increase
+VOLUME_GAIN_DB = 3.0  # ~3dB volume increase
 
 
 def _clamp_tts_speed(speed: float) -> float:


### PR DESCRIPTION
## Summary
- test constant for volume gain
- increase gain to ~3 dB

## Testing
- `python -m unittest tests.text_to_audio.test_tasks.VolumeGainConstantTests.test_volume_gain_constant`
- `python run_all_tests_with_mock.py` *(fails: PermissionError not raised)*

------
https://chatgpt.com/codex/tasks/task_e_68644d2726fc83268a4cde217f2af0a7