### PR TITLE
Allow super admins to manage each other's status

### DIFF
--- a/accounts/templates/accounts/user_management.html
+++ b/accounts/templates/accounts/user_management.html
@@ -64,7 +64,10 @@
                                                 <a href="{% url 'user-revoke-approval' user.id %}" class="btn btn-sm btn-warning">Revoke</a>
                                             {% endif %}
                                             <a href="{% url 'user-reset-password' user.id %}" class="btn btn-sm btn-info">Reset Password</a>
-                                            {% if not user.is_super_admin %}
+                                            {% if user.is_super_admin %}
+                                                <a href="{% url 'user-demote' user.id %}" class="btn btn-sm btn-warning">Demote</a>
+                                            {% else %}
+                                                <a href="{% url 'user-promote' user.id %}" class="btn btn-sm btn-primary">Make Super Admin</a>
                                                 <a href="{% url 'user-delete' user.id %}" class="btn btn-sm btn-danger">Delete</a>
                                             {% endif %}
                                         </div>

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -157,6 +157,48 @@ class UserManagementViewTests(TestCase):
         self.assertFalse(new_user.is_super_admin)
         self.assertFalse(new_user.is_approved)
 
+    def test_promote_user_to_super_admin(self):
+        """Test promoting a user via view."""
+        self.client.login(username="admin", password="testpass123")
+
+        response = self.client.get(reverse("user-promote", args=[self.regular_user.id]))
+        self.assertEqual(response.status_code, 302)
+
+        self.regular_user.refresh_from_db()
+        self.assertTrue(self.regular_user.is_super_admin)
+        self.assertTrue(self.regular_user.is_approved)
+        self.assertTrue(self.regular_user.is_staff)
+        self.assertTrue(self.regular_user.is_superuser)
+
+    def test_demote_user_from_super_admin(self):
+        """Test demoting a user via view."""
+        self.client.login(username="admin", password="testpass123")
+
+        self.regular_user.profile.is_super_admin = True
+        self.regular_user.profile.is_approved = True
+        self.regular_user.profile.save()
+        self.regular_user.is_staff = True
+        self.regular_user.is_superuser = True
+        self.regular_user.save()
+
+        response = self.client.get(reverse("user-demote", args=[self.regular_user.id]))
+        self.assertEqual(response.status_code, 302)
+
+        self.regular_user.refresh_from_db()
+        self.assertFalse(self.regular_user.is_super_admin)
+        self.assertFalse(self.regular_user.is_staff)
+        self.assertFalse(self.regular_user.is_superuser)
+
+    def test_cannot_demote_last_super_admin(self):
+        """Ensure last super admin cannot be demoted."""
+        self.client.login(username="admin", password="testpass123")
+
+        response = self.client.get(reverse("user-demote", args=[self.super_admin.id]))
+        self.assertEqual(response.status_code, 302)
+
+        self.super_admin.refresh_from_db()
+        self.assertTrue(self.super_admin.is_super_admin)
+
 
 @override_settings(
     MIDDLEWARE=[

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -16,6 +16,8 @@ urlpatterns = [
         views.user_reset_password,
         name="user-reset-password",
     ),
+    path("users/<int:user_id>/promote/", views.user_promote, name="user-promote"),
+    path("users/<int:user_id>/demote/", views.user_demote, name="user-demote"),
     path(
         "users/<int:user_id>/delete/",
         views.UserDeleteView.as_view(),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,6 +2,8 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
+
+from accounts.models_profile import UserProfile
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
@@ -135,6 +137,60 @@ def user_reset_password(request, user_id):
         return redirect("user-management")
 
     return render(request, "accounts/user_reset_password.html", {"target_user": user})
+
+
+@login_required
+def user_promote(request, user_id):
+    """Promote a user to super admin."""
+    if not request.user.can_manage_users():
+        return HttpResponseForbidden(
+            "You don't have permission to perform this action."
+        )
+
+    user = get_object_or_404(User, id=user_id)
+
+    if user.is_super_admin:
+        messages.warning(request, f'User "{user.username}" is already a super admin.')
+        return redirect("user-management")
+
+    user.profile.is_super_admin = True
+    user.profile.is_approved = True
+    user.profile.save()
+    user.is_staff = True
+    user.is_superuser = True
+    user.save()
+
+    messages.success(request, f'User "{user.username}" promoted to super admin.')
+    return redirect("user-management")
+
+
+@login_required
+def user_demote(request, user_id):
+    """Demote a user from super admin."""
+    if not request.user.can_manage_users():
+        return HttpResponseForbidden(
+            "You don't have permission to perform this action."
+        )
+
+    user = get_object_or_404(User, id=user_id)
+
+    if not user.is_super_admin:
+        messages.warning(request, f'User "{user.username}" is not a super admin.')
+        return redirect("user-management")
+
+    super_admin_count = UserProfile.objects.filter(is_super_admin=True).count()
+    if super_admin_count <= 1:
+        messages.error(request, "Cannot demote the last super admin.")
+        return redirect("user-management")
+
+    user.profile.is_super_admin = False
+    user.profile.save()
+    user.is_staff = False
+    user.is_superuser = False
+    user.save()
+
+    messages.success(request, f'User "{user.username}" demoted from super admin.')
+    return redirect("user-management")
 
 
 class UserDeleteView(SuperAdminRequiredMixin, LoginRequiredMixin, DeleteView):


### PR DESCRIPTION
## Summary
- add views to promote/demote users to super admin
- expose new URLs for promotion and demotion
- show promote/demote controls on user management page
- cover new behaviour with tests

## Testing
- `python run_all_tests_with_mock.py` *(fails: Permission denied errors)*
- `python run_single_test.py accounts/tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68696f84543c83268d51b7b1618c2abb