### PR TITLE
Fix play button pause toggle

### DIFF
--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -3,6 +3,7 @@
 # mypy: disable-error-code="attr-defined"
 
 import os
+import uuid
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings
@@ -267,3 +268,25 @@ class TestFeedArticleAutoUpdate(TestCase):
         self.assertContains(response, "data-article-id")
         self.assertContains(response, "status-badge")
         self.assertContains(response, "action-cell")
+
+class TestPlayButtonToggle(TestCase):
+    """Tests for play button pause functionality."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = get_user_model().objects.create_user(
+            username="playuser", password="pass123"
+        )
+        self.feed = Feed.objects.create(user=self.user, name="Default")
+        Article.objects.create(
+            feed=self.feed,
+            title="Toggle Test",
+            text_content="sample",
+            status=Article.COMPLETED,
+            audio_uuid=str(uuid.uuid4()),
+        )
+
+    def test_article_list_contains_pause_script(self):
+        self.client.login(username="playuser", password="pass123")
+        response = self.client.get(f"/feeds/{self.feed.pk}/")
+        self.assertContains(response, "audioPlayer.pause(")

--- a/text_to_audio/templates/article_list.html
+++ b/text_to_audio/templates/article_list.html
@@ -379,16 +379,47 @@ function handlePlayButtonClick(event) {
         return;
     }
 
+    const row = button.closest('tr');
+
+    // Compare raw src attribute instead of using audioPlayer.src property
+    const currentSrc = audioPlayer.getAttribute('src') || '';
+
+    // Toggle play/pause if clicking the same audio
+    if (currentSrc === audioUrl) {
+        if (audioPlayer.paused) {
+            document.querySelectorAll('tr.now-playing').forEach(r => r.classList.remove('now-playing'));
+            document.querySelectorAll('.play-audio-btn').forEach(btn => { btn.innerHTML = playIconSvg; });
+            if (row) {
+                row.classList.add('now-playing');
+                button.innerHTML = pauseIconSvg;
+            }
+            const playPromise = audioPlayer.play();
+            if (playPromise !== undefined) {
+                playPromise.catch(error => {
+                    console.error('Audio playback failed:', error);
+                    alert('Failed to play audio. The file may be missing or corrupted.');
+                    resetPlaybackUI();
+                });
+            }
+        } else {
+            audioPlayer.pause();
+            if (row) {
+                row.classList.remove('now-playing');
+                button.innerHTML = playIconSvg;
+            }
+        }
+        return;
+    }
+
     // Remove playing status from all rows
-    document.querySelectorAll('tr.now-playing').forEach(row => {
-        row.classList.remove('now-playing');
+    document.querySelectorAll('tr.now-playing').forEach(r => {
+        r.classList.remove('now-playing');
     });
     document.querySelectorAll('.play-audio-btn').forEach(btn => {
         btn.innerHTML = playIconSvg;
     });
 
     // Add playing status to current row
-    const row = button.closest('tr');
     if (row) {
         row.classList.add('now-playing');
         button.innerHTML = pauseIconSvg;
@@ -402,8 +433,6 @@ function handlePlayButtonClick(event) {
         return;
     }
 
-    // Compare raw src attribute instead of using audioPlayer.src property
-    const currentSrc = audioPlayer.getAttribute('src') || '';
     if (currentSrc !== audioUrl) {
         audioPlayer.setAttribute('src', audioUrl);
     }


### PR DESCRIPTION
## Summary
- add a frontend test ensuring pause logic exists
- update `article_list.html` to toggle pause/play when clicking the same button

## Testing
- `pre-commit run --files tests/test_frontend.py text_to_audio/templates/article_list.html`
- `python run_single_test.py tests/test_frontend.py`
- `python run_all_tests_with_mock.py` *(fails: test_migration_handles_permission_errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c5c149654832694b0a435c8201081