### PR TITLE
Fix missing prompt in voice preset creation

### DIFF
--- a/tests/test_voice_presets.py
+++ b/tests/test_voice_presets.py
@@ -84,6 +84,8 @@ class UserPreferencesServiceTest(TestCase):
             voice_id="fable",
             speed=0.9,
             description="Created via service",
+            prompt="Speak clearly",
+            sample_input="Sample text",
         )
 
         self.assertEqual(preset.name, "Service Test Preset")
@@ -95,6 +97,8 @@ class UserPreferencesServiceTest(TestCase):
             id=preset.id
         )  # type: ignore[attr-defined]
         self.assertEqual(saved_preset.name, "Service Test Preset")
+        self.assertEqual(saved_preset.prompt, "Speak clearly")
+        self.assertEqual(saved_preset.sample_input, "Sample text")
 
     def test_update_preset(self):
         """Test updating a preset via service."""
@@ -295,6 +299,8 @@ class VoicePresetViewsTest(TestCase):
                 "name": "New View Preset",
                 "voice_id": "alloy",
                 "speed": 1.0,
+                "prompt": "View prompt",
+                "sample_input": "View sample",
                 "description": "Created via view test",
             },
         )
@@ -306,6 +312,8 @@ class VoicePresetViewsTest(TestCase):
         preset = UserVoicePreset.objects.get(name="New View Preset")
         self.assertEqual(preset.voice_id, "alloy")
         self.assertEqual(preset.user, self.user)
+        self.assertEqual(preset.prompt, "View prompt")
+        self.assertEqual(preset.sample_input, "View sample")
 
     def test_preset_edit_view(self):
         """Test editing a preset via view."""

--- a/text_to_audio/services/user_preferences.py
+++ b/text_to_audio/services/user_preferences.py
@@ -166,6 +166,8 @@ class UserPreferencesService:
         voice_id,
         speed,
         description="",
+        prompt="",
+        sample_input="",
         affect=None,
         tone=None,
         pacing=None,
@@ -181,6 +183,8 @@ class UserPreferencesService:
             voice_id: Voice ID for the preset
             speed: Speed for the preset
             description: Optional description
+            prompt: Optional TTS instructions
+            sample_input: Optional sample text used for design
             affect: Optional emotional affect
             tone: Optional tone descriptor
             pacing: Optional pacing style
@@ -198,6 +202,8 @@ class UserPreferencesService:
             voice_id=voice_id,
             speed=float(speed),
             description=description,
+            prompt=prompt,
+            sample_input=sample_input,
             affect=affect,
             tone=tone,
             pacing=pacing,
@@ -214,6 +220,8 @@ class UserPreferencesService:
         voice_id=None,
         speed=None,
         description=None,
+        prompt=None,
+        sample_input=None,
         affect=None,
         tone=None,
         pacing=None,
@@ -229,6 +237,8 @@ class UserPreferencesService:
             voice_id: New voice ID for the preset
             speed: New speed for the preset
             description: New description for the preset
+            prompt: New TTS instructions
+            sample_input: New sample input text
             affect: New emotional affect
             tone: New tone descriptor
             pacing: New pacing style
@@ -254,6 +264,12 @@ class UserPreferencesService:
 
             if description is not None:
                 preset.description = description
+
+            if prompt is not None:
+                preset.prompt = prompt
+
+            if sample_input is not None:
+                preset.sample_input = sample_input
 
             if affect is not None:
                 preset.affect = affect

--- a/text_to_audio/views.py
+++ b/text_to_audio/views.py
@@ -1091,6 +1091,8 @@ def voice_preset_create(request):
                 voice_id=form.cleaned_data["voice_id"],
                 speed=form.cleaned_data["speed"],
                 description=form.cleaned_data["description"],
+                prompt=form.cleaned_data["prompt"],
+                sample_input=form.cleaned_data["sample_input"],
             )
 
             messages.success(


### PR DESCRIPTION
### **User description**
## Summary
- save prompt and sample text when creating voice presets
- allow updating prompt/sample via the service
- include prompt and sample input in preset creation view
- test that presets preserve these fields

## Testing
- `python run_single_test.py tests/test_voice_presets.py`

------
https://chatgpt.com/codex/tasks/task_e_686c5d5309548326b825205a58cacaf3


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Accept `prompt` and `sample_input` in service

- Save and update new fields on presets

- Pass new inputs in view preset creation

- Update tests to assert prompt and sample input


___

### **Changes diagram**

```mermaid
flowchart LR
  A["User POST preset form"] -- includes prompt/sample --> B["voice_preset_create view"]
  B -- calls create_voice_preset --> C["UserPreferencesService"]
  C -- assigns prompt/sample --> D["UserVoicePreset model"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_voice_presets.py</strong><dd><code>Add prompt and sample_input assertions in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_voice_presets.py

<li>Added <code>prompt</code> and <code>sample_input</code> to service tests<br> <li> Extended view create tests with new fields<br> <li> Added assertions for prompt and sample_input


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/161/files#diff-0b2939d510f18c3135f4b4894a951e343aa1401099ecbf05865ac30ff386eb43">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user_preferences.py</strong><dd><code>Support prompt and sample_input in service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/services/user_preferences.py

<li>Introduced <code>prompt</code> and <code>sample_input</code> parameters<br> <li> Set default values for new fields<br> <li> Saved new fields in create/update methods


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/161/files#diff-a9bd4eac03f6e657c7a37c11227e722e2ed54b46ec9642ab48452ab44eecabe0">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Forward prompt and sample_input in view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/views.py

<li>Passed <code>prompt</code> and <code>sample_input</code> from form<br> <li> Updated view to forward new fields to service


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/161/files#diff-9550890abb2c0f1498b48b7097fec6807b4b48079d3824e59eaf7d73759966c7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>