### PR TITLE
Prevent password manager autofill on email inputs

### DIFF
--- a/text_to_audio/templates/article_list.html
+++ b/text_to_audio/templates/article_list.html
@@ -88,7 +88,7 @@ tr.now-playing {
         <div class="card-body">
             <p class="card-text">Forward emails or newsletters to this address to automatically add them to your feed:</p>
             <div class="input-group mb-3">
-                <input type="text" class="form-control" value="{{ feed.inbound_email }}" id="feed-email" readonly>
+                <input type="text" class="form-control" value="{{ feed.inbound_email }}" id="feed-email" readonly autocomplete="off" data-lpignore="true" data-1p-ignore data-form-type="other">
                 <button class="btn btn-outline-secondary" type="button" onclick="copyFeedEmail()" id="copy-email-button">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard" viewBox="0 0 16 16">
                         <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/>

--- a/text_to_audio/templates/feed_list.html
+++ b/text_to_audio/templates/feed_list.html
@@ -43,7 +43,7 @@
                                             <i class="bi bi-envelope"></i> Email to Feed:
                                         </label>
                                         <div class="input-group input-group-sm">
-                                            <input type="text" class="form-control" value="{{ feed.inbound_email }}" readonly id="email-{{ feed.id }}">
+                                            <input type="text" class="form-control" value="{{ feed.inbound_email }}" readonly id="email-{{ feed.id }}" autocomplete="off" data-lpignore="true" data-1p-ignore data-form-type="other">
                                             <button class="btn btn-outline-secondary" type="button" onclick="copyToClipboard('email-{{ feed.id }}')">
                                                 <i class="bi bi-clipboard"></i> Copy
                                             </button>


### PR DESCRIPTION
### **User description**
Add autocomplete="off" and vendor-specific attributes (data-lpignore, data-1p-ignore, data-form-type) to prevent password managers from trying to fill the readonly email address display fields.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Disable password manager autofill on email fields

- Add vendor-specific ignore attributes for inputs

- Preserve readonly display for inbound email values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Readonly inbound email inputs"] -- "add attributes" --> B["autocomplete='off'"]
  A -- "add attributes" --> C["data-lpignore='true'"]
  A -- "add attributes" --> D["data-1p-ignore"]
  A -- "set type" --> E["data-form-type='other'"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>article_list.html</strong><dd><code>Prevent autofill on feed email input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/templates/article_list.html

<ul><li>Add autocomplete="off" to email input<br> <li> Add data-lpignore, data-1p-ignore attributes<br> <li> Set data-form-type="other" on input<br> <li> Keep field readonly and copy button</ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/162/files#diff-e50328adcce791cd2d453424bf79ca870d497a43a9293b092391c49aaaab8e22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>feed_list.html</strong><dd><code>Disable autofill on email-to-feed display field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/templates/feed_list.html

<ul><li>Add autocomplete="off" to email display input<br> <li> Add data-lpignore and data-1p-ignore flags<br> <li> Set data-form-type="other" attribute<br> <li> Maintain readonly behavior and copy action</ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/162/files#diff-c0482fdab7371cc7f5877afdcd0165bb5b66b6c857f5d94fc305037788142358">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

