### PR TITLE
fix: update tests to match current TTS service implementation [AI]

### DIFF
--- a/tests/test_canonical_media_paths.py
+++ b/tests/test_canonical_media_paths.py
@@ -116,6 +116,10 @@ class CanonicalMediaPathsTestCase(TestCase):
 
     def test_canonical_path_permission_handling(self):
         """Test handling of permission issues when creating directories."""
+        # Skip this test if running as root (permissions don't apply)
+        if os.geteuid() == 0:
+            self.skipTest("Test skipped when running as root")
+
         with tempfile.TemporaryDirectory() as temp_dir:
             with override_settings(MEDIA_ROOT=temp_dir):
                 # Make the temp directory read-only

--- a/tests/test_migrate_audio_paths.py
+++ b/tests/test_migrate_audio_paths.py
@@ -177,6 +177,10 @@ class MigrateAudioPathsTestCase(TestCase):
 
     def test_migration_handles_permission_errors(self):
         """Test migration handles permission errors gracefully."""
+        # Skip this test if running as root (permissions don't apply)
+        if os.geteuid() == 0:
+            self.skipTest("Test skipped when running as root")
+
         with tempfile.TemporaryDirectory() as temp_dir:
             with override_settings(MEDIA_ROOT=temp_dir):
                 # Create legacy file

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -405,7 +405,7 @@ class ArticleGetDisplayVoiceNameTests(TestCase):
     def test_standard_voice_only(self):
         """Test with only a standard 'voice' set (e.g., 'nova')."""
         article = Article.objects.create(feed=self.feed, title="Test", voice="nova")
-        self.assertEqual(article.get_display_voice_name, "Nova")
+        self.assertEqual(article.get_display_voice_name, "Nova (OpenAI)")
 
     def test_standard_voice_with_multivoice(self):
         """Test with a standard 'voice' and multi_voice_data."""
@@ -415,7 +415,7 @@ class ArticleGetDisplayVoiceNameTests(TestCase):
             voice="nova",
             multi_voice_data={"key": "value"},
         )
-        self.assertEqual(article.get_display_voice_name, "Nova - Multi-Voice")
+        self.assertEqual(article.get_display_voice_name, "Nova (OpenAI) - Multi-Voice")
 
     def test_custom_voice_id_only(self):
         """Test with a custom 'voice_id' set."""

--- a/tests/test_verse_voice_removal.py
+++ b/tests/test_verse_voice_removal.py
@@ -65,8 +65,9 @@ class VerseVoiceRemovalTest(TestCase):
         voice_ids = [choice[0] for choice in VOICE_CHOICES]
         self.assertNotIn("verse", voice_ids)
 
-        # Verify all expected voices are present
-        expected_voices = {
+        # Verify core OpenAI voices are present (subset check, not exact equality)
+        # since additional providers like Google TTS have been added
+        expected_openai_voices = {
             "alloy",
             "ash",
             "ballad",
@@ -78,7 +79,10 @@ class VerseVoiceRemovalTest(TestCase):
             "sage",
             "shimmer",
         }
-        self.assertEqual(set(voice_ids), expected_voices)
+        self.assertTrue(
+            expected_openai_voices.issubset(set(voice_ids)),
+            f"Missing OpenAI voices. Expected {expected_openai_voices} to be subset of {set(voice_ids)}",
+        )
 
     def test_article_accepts_valid_voices(self):
         """Test that articles can still be created with valid voices."""

--- a/tests/test_voice_presets.py
+++ b/tests/test_voice_presets.py
@@ -184,7 +184,9 @@ class VoiceConfigurationServiceTest(TestCase):
     def test_get_available_voices(self):
         """Service returns the full list of available voices."""
         voices = dict(self.service.get_available_voices())
-        expected = {
+        # Check that core OpenAI voices are present (subset check)
+        # since additional providers like Google TTS have been added
+        expected_openai_voices = {
             "alloy",
             "ash",
             "ballad",
@@ -196,7 +198,10 @@ class VoiceConfigurationServiceTest(TestCase):
             "sage",
             "shimmer",
         }
-        self.assertEqual(set(voices.keys()), expected)
+        self.assertTrue(
+            expected_openai_voices.issubset(set(voices.keys())),
+            f"Missing OpenAI voices. Expected {expected_openai_voices} to be subset of {set(voices.keys())}",
+        )
 
     def test_get_user_presets(self):
         """Test getting presets for a user."""

--- a/tests/text_to_audio/test_firecrawl.py
+++ b/tests/text_to_audio/test_firecrawl.py
@@ -2,12 +2,12 @@
 
 from unittest.mock import patch
 
-from django.test import SimpleTestCase, override_settings
+from django.test import TestCase, override_settings
 
 from text_to_audio.utils import process_url_to_text
 
 
-class FirecrawlTests(SimpleTestCase):
+class FirecrawlTests(TestCase):
     """Firecrawl integration tests for URL processing."""
 
     @override_settings(FIRECRAWL_API_KEY="key", USE_FIRECRAWL_BY_DEFAULT=True)
@@ -46,5 +46,5 @@ class FirecrawlTests(SimpleTestCase):
         self.assertTrue(success)
         self.assertEqual(text, "txt")
         self.assertIsNone(error)
-        mock_fetch.assert_called_once_with("https://example.com")
+        mock_fetch.assert_called_once_with("https://example.com", max_retries=1)
         mock_firecrawl.assert_called_once_with("https://example.com")

--- a/tests/text_to_audio/test_google_tts_provider.py
+++ b/tests/text_to_audio/test_google_tts_provider.py
@@ -1,10 +1,9 @@
 """Tests for GoogleTTSProvider."""
 
-from unittest.mock import MagicMock, Mock, patch
+import json
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
-
-from text_to_audio.services.google_tts_provider import GoogleTTSProvider
 
 
 class GoogleTTSProviderTest(TestCase):
@@ -23,293 +22,250 @@ class GoogleTTSProviderTest(TestCase):
             "token_uri": "https://oauth2.googleapis.com/token",
         }
 
-    @patch("text_to_audio.services.google_tts_provider.get_google_tts_credentials")
-    def test_init_raises_without_credentials(self, mock_get_creds):
+    def _create_provider_with_mocks(self):
+        """Helper to create a GoogleTTSProvider with mocked dependencies."""
+        with patch("appconfig.utils.get_google_tts_api_key") as mock_api_key, patch(
+            "appconfig.utils.get_google_tts_credentials"
+        ) as mock_creds:
+            mock_api_key.return_value = "test-api-key"
+            mock_creds.return_value = None
+
+            # Mock the Google Cloud client
+            with patch(
+                "google.api_core.client_options.ClientOptions"
+            ) as mock_client_opts, patch(
+                "google.cloud.texttospeech_v1.TextToSpeechClient"
+            ) as mock_tts_client:
+                mock_client_opts.return_value = MagicMock()
+                mock_client = MagicMock()
+                mock_tts_client.return_value = mock_client
+
+                from text_to_audio.services.google_tts_provider import (
+                    GoogleTTSProvider,
+                )
+
+                provider = GoogleTTSProvider()
+                return provider, mock_client
+
+    def test_init_raises_without_credentials(self):
         """Test GoogleTTSProvider raises ValueError if credentials not configured."""
-        mock_get_creds.return_value = None
+        with patch("appconfig.utils.get_google_tts_api_key") as mock_api_key, patch(
+            "appconfig.utils.get_google_tts_credentials"
+        ) as mock_creds:
+            mock_api_key.return_value = None
+            mock_creds.return_value = None
 
-        with self.assertRaises(ValueError) as cm:
-            GoogleTTSProvider()
+            from text_to_audio.services.google_tts_provider import GoogleTTSProvider
 
-        self.assertIn("Google TTS credentials not configured", str(cm.exception))
+            with self.assertRaises(ValueError) as cm:
+                GoogleTTSProvider()
 
-    @patch("text_to_audio.services.google_tts_provider.get_google_tts_credentials")
-    @patch("text_to_audio.services.google_tts_provider.service_account")
-    @patch("text_to_audio.services.google_tts_provider.texttospeech_v1")
-    def test_init_with_dict_credentials(
-        self, mock_tts_v1, mock_service_account, mock_get_creds
-    ):
+            self.assertIn("Google TTS credentials not configured", str(cm.exception))
+
+    def test_init_with_dict_credentials(self):
         """Test GoogleTTSProvider initializes with dict credentials."""
-        mock_get_creds.return_value = self.mock_credentials
+        with patch("appconfig.utils.get_google_tts_api_key") as mock_api_key, patch(
+            "appconfig.utils.get_google_tts_credentials"
+        ) as mock_creds, patch(
+            "google.oauth2.service_account.Credentials.from_service_account_info"
+        ) as mock_from_sa, patch(
+            "google.cloud.texttospeech_v1.TextToSpeechClient"
+        ) as mock_tts_client:
+            mock_api_key.return_value = None  # No API key
+            mock_creds.return_value = self.mock_credentials  # Service account creds
 
-        mock_credentials_obj = MagicMock()
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_credentials_obj
-        )
+            mock_credentials_obj = MagicMock()
+            mock_from_sa.return_value = mock_credentials_obj
 
-        mock_client = MagicMock()
-        mock_tts_v1.TextToSpeechClient.return_value = mock_client
+            mock_client = MagicMock()
+            mock_tts_client.return_value = mock_client
 
-        provider = GoogleTTSProvider()
+            from text_to_audio.services.google_tts_provider import GoogleTTSProvider
 
-        # Verify credentials were parsed
-        mock_service_account.Credentials.from_service_account_info.assert_called_once_with(
-            self.mock_credentials
-        )
+            provider = GoogleTTSProvider()
 
-        # Verify client was created
-        mock_tts_v1.TextToSpeechClient.assert_called_once_with(
-            credentials=mock_credentials_obj
-        )
+            # Verify credentials were parsed
+            mock_from_sa.assert_called_once_with(self.mock_credentials)
 
-        self.assertEqual(provider.client, mock_client)
+            # Verify client was created
+            mock_tts_client.assert_called_once_with(credentials=mock_credentials_obj)
 
-    @patch("text_to_audio.services.google_tts_provider.get_google_tts_credentials")
-    @patch("text_to_audio.services.google_tts_provider.service_account")
-    @patch("text_to_audio.services.google_tts_provider.texttospeech_v1")
-    @patch("text_to_audio.services.google_tts_provider.json.loads")
-    def test_init_with_string_credentials(
-        self, mock_json_loads, mock_tts_v1, mock_service_account, mock_get_creds
-    ):
+            self.assertEqual(provider.client, mock_client)
+
+    def test_init_with_string_credentials(self):
         """Test GoogleTTSProvider parses string credentials."""
-        credentials_json = '{"type": "service_account", "project_id": "test"}'
-        mock_get_creds.return_value = credentials_json
-        mock_json_loads.return_value = self.mock_credentials
+        credentials_json = json.dumps(self.mock_credentials)
 
-        mock_credentials_obj = MagicMock()
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_credentials_obj
-        )
+        with patch("appconfig.utils.get_google_tts_api_key") as mock_api_key, patch(
+            "appconfig.utils.get_google_tts_credentials"
+        ) as mock_creds, patch(
+            "google.oauth2.service_account.Credentials.from_service_account_info"
+        ) as mock_from_sa, patch(
+            "google.cloud.texttospeech_v1.TextToSpeechClient"
+        ) as mock_tts_client:
+            mock_api_key.return_value = None
+            mock_creds.return_value = credentials_json
 
-        mock_client = MagicMock()
-        mock_tts_v1.TextToSpeechClient.return_value = mock_client
+            mock_credentials_obj = MagicMock()
+            mock_from_sa.return_value = mock_credentials_obj
 
-        provider = GoogleTTSProvider()
+            mock_client = MagicMock()
+            mock_tts_client.return_value = mock_client
 
-        # Verify JSON was parsed
-        mock_json_loads.assert_called_once_with(credentials_json)
+            from text_to_audio.services.google_tts_provider import GoogleTTSProvider
 
-        self.assertIsNotNone(provider.client)
+            provider = GoogleTTSProvider()
 
-    @patch("text_to_audio.services.google_tts_provider.get_google_tts_credentials")
-    def test_init_raises_on_invalid_json(self, mock_get_creds):
+            # Verify credentials were parsed from JSON string
+            mock_from_sa.assert_called_once()
+
+            self.assertIsNotNone(provider.client)
+
+    def test_init_raises_on_invalid_json(self):
         """Test GoogleTTSProvider raises ValueError on invalid JSON credentials."""
-        mock_get_creds.return_value = "invalid json {{"
+        with patch("appconfig.utils.get_google_tts_api_key") as mock_api_key, patch(
+            "appconfig.utils.get_google_tts_credentials"
+        ) as mock_creds:
+            mock_api_key.return_value = None
+            mock_creds.return_value = "invalid json {{"
 
-        with self.assertRaises(ValueError) as cm:
-            GoogleTTSProvider()
+            from text_to_audio.services.google_tts_provider import GoogleTTSProvider
 
-        self.assertIn("Invalid Google TTS credentials JSON", str(cm.exception))
+            with self.assertRaises(ValueError) as cm:
+                GoogleTTSProvider()
+
+            self.assertIn("Invalid Google TTS credentials JSON", str(cm.exception))
 
     def test_get_voice_type_gemini(self):
         """Test voice type detection for Gemini voices."""
-        with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch("text_to_audio.services.google_tts_provider.texttospeech_v1"):
-                provider = GoogleTTSProvider()
+        provider, _ = self._create_provider_with_mocks()
 
-                # Test Journey voice (Gemini)
-                voice_type = provider._get_voice_type("en-US-Journey-D")
-                self.assertEqual(voice_type, "gemini")
+        # Test Journey voice (Gemini)
+        voice_type = provider._get_voice_type("en-US-Journey-D")
+        self.assertEqual(voice_type, "gemini")
 
-                # Test Gemini in name
-                voice_type = provider._get_voice_type("en-US-Gemini-A")
-                self.assertEqual(voice_type, "gemini")
+        # Test short Gemini voice name
+        voice_type = provider._get_voice_type("Charon")
+        self.assertEqual(voice_type, "gemini")
 
     def test_get_voice_type_chirp3(self):
         """Test voice type detection for Chirp3 voices."""
-        with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch("text_to_audio.services.google_tts_provider.texttospeech_v1"):
-                provider = GoogleTTSProvider()
+        provider, _ = self._create_provider_with_mocks()
 
-                voice_type = provider._get_voice_type("en-US-Chirp3-HD-Charon")
-                self.assertEqual(voice_type, "chirp3")
+        voice_type = provider._get_voice_type("en-US-Chirp3-HD-Charon")
+        self.assertEqual(voice_type, "chirp3")
 
     def test_get_voice_type_neural2(self):
         """Test voice type detection for Neural2 voices."""
-        with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch("text_to_audio.services.google_tts_provider.texttospeech_v1"):
-                provider = GoogleTTSProvider()
+        provider, _ = self._create_provider_with_mocks()
 
-                voice_type = provider._get_voice_type("en-US-Neural2-A")
-                self.assertEqual(voice_type, "neural2")
+        voice_type = provider._get_voice_type("en-US-Neural2-A")
+        self.assertEqual(voice_type, "neural2")
 
-    @patch("text_to_audio.services.google_tts_provider.get_google_tts_voice_type")
-    def test_get_voice_type_unknown_defaults(self, mock_get_default_type):
+    def test_get_voice_type_unknown_defaults(self):
         """Test voice type defaults to config value for unknown voices."""
-        mock_get_default_type.return_value = "gemini"
-
         with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch("text_to_audio.services.google_tts_provider.texttospeech_v1"):
-                provider = GoogleTTSProvider()
+            "appconfig.utils.get_google_tts_voice_type"
+        ) as mock_get_default_type:
+            mock_get_default_type.return_value = "gemini"
 
-                voice_type = provider._get_voice_type("en-US-Unknown-Voice")
-                self.assertEqual(voice_type, "gemini")
-                mock_get_default_type.assert_called_once()
+            provider, _ = self._create_provider_with_mocks()
+
+            voice_type = provider._get_voice_type("en-US-Unknown-Voice")
+            self.assertEqual(voice_type, "gemini")
+            mock_get_default_type.assert_called_once()
 
     def test_build_voice_params_basic(self):
-        """Test building voice parameters from voice name."""
+        """Test building voice parameters for non-gemini voice."""
+        provider, _ = self._create_provider_with_mocks()
+
         with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch(
-                "text_to_audio.services.google_tts_provider.texttospeech_v1"
-            ) as mock_tts_v1:
-                provider = GoogleTTSProvider()
+            "google.cloud.texttospeech_v1.VoiceSelectionParams"
+        ) as mock_voice_params_cls:
+            mock_voice_params = MagicMock()
+            mock_voice_params_cls.return_value = mock_voice_params
 
-                mock_voice_params = MagicMock()
-                mock_tts_v1.VoiceSelectionParams.return_value = mock_voice_params
+            # Test non-gemini voice (chirp3) - doesn't use model_name
+            result = provider._build_voice_params(
+                "en-US-Chirp3-HD-Charon", "chirp3", "pro"
+            )
 
-                result = provider._build_voice_params(
-                    "en-US-Journey-D", "gemini", None
-                )
+            # Verify VoiceSelectionParams called with correct language code and name
+            mock_voice_params_cls.assert_called_with(
+                language_code="en-US", name="en-US-Chirp3-HD-Charon"
+            )
 
-                # Verify VoiceSelectionParams called with correct language code
-                mock_tts_v1.VoiceSelectionParams.assert_called_once_with(
-                    language_code="en-US", name="en-US-Journey-D"
-                )
-
-                self.assertEqual(result, mock_voice_params)
+            self.assertEqual(result, mock_voice_params)
 
     def test_build_voice_params_extracts_language_code(self):
         """Test language code extraction from voice name."""
+        provider, _ = self._create_provider_with_mocks()
+
         with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch(
-                "text_to_audio.services.google_tts_provider.texttospeech_v1"
-            ) as mock_tts_v1:
-                provider = GoogleTTSProvider()
+            "google.cloud.texttospeech_v1.VoiceSelectionParams"
+        ) as mock_voice_params_cls:
+            provider._build_voice_params("fr-FR-Neural2-B", "neural2", None)
 
-                provider._build_voice_params("fr-FR-Neural2-B", "neural2", None)
-
-                # Verify language code extracted correctly
-                call_args = mock_tts_v1.VoiceSelectionParams.call_args[1]
-                self.assertEqual(call_args["language_code"], "fr-FR")
+            # Verify language code extracted correctly
+            call_args = mock_voice_params_cls.call_args[1]
+            self.assertEqual(call_args["language_code"], "fr-FR")
 
     def test_build_voice_params_defaults_language_code(self):
         """Test language code defaults to en-US for invalid formats."""
+        provider, _ = self._create_provider_with_mocks()
+
         with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch(
-                "text_to_audio.services.google_tts_provider.texttospeech_v1"
-            ) as mock_tts_v1:
-                provider = GoogleTTSProvider()
+            "google.cloud.texttospeech_v1.VoiceSelectionParams"
+        ) as mock_voice_params_cls:
+            # For non-gemini voice type, test with invalid format
+            provider._build_voice_params("InvalidVoiceName", "neural2", None)
 
-                provider._build_voice_params("InvalidVoiceName", "gemini", None)
-
-                # Verify language code defaults to en-US
-                call_args = mock_tts_v1.VoiceSelectionParams.call_args[1]
-                self.assertEqual(call_args["language_code"], "en-US")
+            # Verify language code defaults to en-US
+            call_args = mock_voice_params_cls.call_args[1]
+            self.assertEqual(call_args["language_code"], "en-US")
 
     def test_get_audio_encoding_mp3(self):
         """Test audio encoding mapping for MP3."""
-        with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch(
-                "text_to_audio.services.google_tts_provider.texttospeech_v1"
-            ) as mock_tts_v1:
-                provider = GoogleTTSProvider()
+        from google.cloud import texttospeech_v1
 
-                encoding = provider._get_audio_encoding("mp3")
+        provider, _ = self._create_provider_with_mocks()
 
-                self.assertEqual(encoding, mock_tts_v1.AudioEncoding.MP3)
+        encoding = provider._get_audio_encoding("mp3")
+
+        self.assertEqual(encoding, texttospeech_v1.AudioEncoding.MP3)
 
     def test_get_audio_encoding_wav(self):
         """Test audio encoding mapping for WAV."""
-        with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch(
-                "text_to_audio.services.google_tts_provider.texttospeech_v1"
-            ) as mock_tts_v1:
-                provider = GoogleTTSProvider()
+        from google.cloud import texttospeech_v1
 
-                encoding = provider._get_audio_encoding("wav")
+        provider, _ = self._create_provider_with_mocks()
 
-                self.assertEqual(encoding, mock_tts_v1.AudioEncoding.LINEAR16)
+        encoding = provider._get_audio_encoding("wav")
+
+        self.assertEqual(encoding, texttospeech_v1.AudioEncoding.LINEAR16)
 
     def test_get_audio_encoding_defaults(self):
         """Test audio encoding defaults to LINEAR16 for unknown formats."""
-        with patch(
-            "text_to_audio.services.google_tts_provider.get_google_tts_credentials"
-        ) as mock_get_creds:
-            mock_get_creds.return_value = self.mock_credentials
-            with patch(
-                "text_to_audio.services.google_tts_provider.service_account"
-            ), patch(
-                "text_to_audio.services.google_tts_provider.texttospeech_v1"
-            ) as mock_tts_v1:
-                provider = GoogleTTSProvider()
+        from google.cloud import texttospeech_v1
 
-                encoding = provider._get_audio_encoding("unknown")
+        provider, _ = self._create_provider_with_mocks()
 
-                self.assertEqual(encoding, mock_tts_v1.AudioEncoding.LINEAR16)
+        encoding = provider._get_audio_encoding("unknown")
 
-    @patch("text_to_audio.services.google_tts_provider.get_google_tts_credentials")
-    @patch("text_to_audio.services.google_tts_provider.service_account")
-    @patch("text_to_audio.services.google_tts_provider.texttospeech_v1")
-    def test_synthesize_speech_success(
-        self, mock_tts_v1, mock_service_account, mock_get_creds
-    ):
+        self.assertEqual(encoding, texttospeech_v1.AudioEncoding.LINEAR16)
+
+    def test_synthesize_speech_success(self):
         """Test successful speech synthesis."""
-        mock_get_creds.return_value = self.mock_credentials
-
-        mock_credentials_obj = MagicMock()
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_credentials_obj
-        )
-
-        # Mock client and response
-        mock_client = MagicMock()
-        mock_tts_v1.TextToSpeechClient.return_value = mock_client
+        provider, mock_client = self._create_provider_with_mocks()
 
         mock_response = MagicMock()
         mock_response.audio_content = b"synthesized_audio_data"
         mock_client.synthesize_speech.return_value = mock_response
 
-        provider = GoogleTTSProvider()
-
-        # Synthesize speech
+        # Synthesize speech (use Neural2 voice for simpler test)
         audio_bytes = provider.synthesize_speech(
             text="Hello world",
-            voice_name="en-US-Journey-D",
+            voice_name="en-US-Neural2-A",
             speed=1.0,
             output_format="wav",
         )
@@ -320,61 +276,35 @@ class GoogleTTSProviderTest(TestCase):
         # Verify API was called
         mock_client.synthesize_speech.assert_called_once()
 
-    @patch("text_to_audio.services.google_tts_provider.get_google_tts_credentials")
-    @patch("text_to_audio.services.google_tts_provider.service_account")
-    @patch("text_to_audio.services.google_tts_provider.texttospeech_v1")
-    def test_synthesize_speech_with_speed(
-        self, mock_tts_v1, mock_service_account, mock_get_creds
-    ):
-        """Test speech synthesis includes speaking rate."""
-        mock_get_creds.return_value = self.mock_credentials
-
-        mock_credentials_obj = MagicMock()
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_credentials_obj
-        )
-
-        mock_client = MagicMock()
-        mock_tts_v1.TextToSpeechClient.return_value = mock_client
+    def test_synthesize_speech_with_speed(self):
+        """Test speech synthesis includes speaking rate for non-gemini voices."""
+        provider, mock_client = self._create_provider_with_mocks()
 
         mock_response = MagicMock()
         mock_response.audio_content = b"audio"
         mock_client.synthesize_speech.return_value = mock_response
 
-        provider = GoogleTTSProvider()
+        with patch("google.cloud.texttospeech_v1.AudioConfig") as mock_audio_config:
+            mock_audio_config.return_value = MagicMock()
 
-        # Synthesize with custom speed
-        provider.synthesize_speech(
-            text="Test", voice_name="en-US-Journey-D", speed=1.5
-        )
+            # Synthesize with custom speed (use Neural2 voice which supports speaking_rate)
+            provider.synthesize_speech(
+                text="Test", voice_name="en-US-Neural2-A", speed=1.5
+            )
 
-        # Verify AudioConfig includes speaking_rate
-        call_args = mock_client.synthesize_speech.call_args[1]
-        self.assertEqual(call_args["audio_config"].speaking_rate, 1.5)
+            # Verify AudioConfig was called with speaking_rate
+            mock_audio_config.assert_called()
+            call_kwargs = mock_audio_config.call_args[1]
+            self.assertEqual(call_kwargs.get("speaking_rate"), 1.5)
 
-    @patch("text_to_audio.services.google_tts_provider.get_google_tts_credentials")
-    @patch("text_to_audio.services.google_tts_provider.service_account")
-    @patch("text_to_audio.services.google_tts_provider.texttospeech_v1")
-    def test_synthesize_speech_api_error(
-        self, mock_tts_v1, mock_service_account, mock_get_creds
-    ):
+    def test_synthesize_speech_api_error(self):
         """Test speech synthesis handles API errors."""
-        mock_get_creds.return_value = self.mock_credentials
-
-        mock_credentials_obj = MagicMock()
-        mock_service_account.Credentials.from_service_account_info.return_value = (
-            mock_credentials_obj
-        )
-
-        mock_client = MagicMock()
-        mock_tts_v1.TextToSpeechClient.return_value = mock_client
+        provider, mock_client = self._create_provider_with_mocks()
 
         # Simulate API error
         mock_client.synthesize_speech.side_effect = Exception("API Error")
 
-        provider = GoogleTTSProvider()
-
         with self.assertRaises(ValueError) as cm:
-            provider.synthesize_speech(text="Test", voice_name="en-US-Journey-D")
+            provider.synthesize_speech(text="Test", voice_name="en-US-Neural2-A")
 
         self.assertIn("Google TTS synthesis failed", str(cm.exception))

--- a/tests/text_to_audio/test_speed_control_chunk_tone.py
+++ b/tests/text_to_audio/test_speed_control_chunk_tone.py
@@ -123,9 +123,8 @@ class SpeedControlChunkToneTests(TestCase):
 
         mock_tts_response = MagicMock()
         mock_tts_response.usage = MagicMock(total_tokens=50)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         # Mock audio processing
@@ -248,9 +247,8 @@ class SpeedControlChunkToneTests(TestCase):
 
         mock_tts_response = MagicMock()
         mock_tts_response.usage = MagicMock(total_tokens=50)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         # Mock audio processing
@@ -348,9 +346,8 @@ class SpeedControlChunkToneTests(TestCase):
 
         mock_tts_response = MagicMock()
         mock_tts_response.usage = MagicMock(total_tokens=50)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         # Mock audio processing

--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -312,9 +312,8 @@ class ProcessArticleTests(TestCase):
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
         mock_tts_response.usage = MagicMock(total_tokens=123)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         self.article.voice_parameters = None
@@ -350,9 +349,8 @@ class ProcessArticleTests(TestCase):
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
         mock_tts_response.usage = MagicMock(total_tokens=100)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         mock_analysis_instance = MockContentAnalysisService.return_value
@@ -404,9 +402,8 @@ class ProcessArticleTests(TestCase):
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
         mock_tts_response.usage = MagicMock(total_tokens=10)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         result = process_article(self.article.id)
@@ -432,9 +429,8 @@ class ProcessArticleTests(TestCase):
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
         mock_tts_response.usage = MagicMock(total_tokens=50)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
         chunks_data = ["Chunk 1 content.", "Second chunk here."]  # 3 words, 3 words
 
@@ -470,13 +466,12 @@ class ProcessArticleTests(TestCase):
 
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
-        mock_tts_response = MagicMock(spec=["stream_to_file"])
+        mock_tts_response = MagicMock(spec=["iter_bytes"])
         usage_mock = MagicMock()
         usage_mock.total_tokens = 100
         type(mock_tts_response).usage = PropertyMock(return_value=usage_mock)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
         self.article.multi_voice_data = None  # Ensure fallback path
         self.article.save()
@@ -507,12 +502,11 @@ class ProcessArticleTests(TestCase):
         self._setup_audio_mocks(mock_audio_empty, mock_audio_from_file)
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
-        mock_tts_response = MagicMock(spec=["headers", "stream_to_file"])
+        mock_tts_response = MagicMock(spec=["headers", "iter_bytes"])
         mock_tts_response.headers = {"x-openai-tokens-used": "150"}
         type(mock_tts_response).usage = PropertyMock(side_effect=AttributeError)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
         process_article(self.article.id)
         mock_save_stats.assert_called_once()
@@ -527,12 +521,11 @@ class ProcessArticleTests(TestCase):
         self._setup_audio_mocks(mock_audio_empty, mock_audio_from_file)
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
-        mock_tts_response = MagicMock(spec=["headers", "stream_to_file"])
+        mock_tts_response = MagicMock(spec=["headers", "iter_bytes"])
         mock_tts_response.headers = {"some-other-header": "some-value"}
         type(mock_tts_response).usage = PropertyMock(side_effect=AttributeError)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
         process_article(self.article.id)
         mock_save_stats.assert_called_once()
@@ -572,9 +565,8 @@ class ProcessArticleTests(TestCase):
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         mock_audio_from_file.side_effect = Exception(
@@ -622,13 +614,12 @@ class ProcessArticleTests(TestCase):
         self._setup_audio_mocks(mock_audio_empty, mock_audio_from_file)
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
-        mock_tts_response = MagicMock(spec=["stream_to_file"])
+        mock_tts_response = MagicMock(spec=["iter_bytes"])
         usage_mock = MagicMock()
         usage_mock.total_tokens = 100
         type(mock_tts_response).usage = PropertyMock(return_value=usage_mock)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
         chunks = ["Chunk one for cleanup.", "Chunk two for cleanup."]
         with patch(
@@ -654,9 +645,8 @@ class ProcessArticleTests(TestCase):
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_successful_tts_response = MagicMock()
-        mock_successful_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_successful_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.side_effect = [
             mock_successful_tts_response,
             OpenAIAPIError(
@@ -695,9 +685,8 @@ class ProcessArticleTests(TestCase):
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         expected_summary = "Multi-voice summary."
@@ -738,9 +727,8 @@ class ProcessArticleTests(TestCase):
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         expected_summary = "Summary from invalid data"
@@ -777,9 +765,8 @@ class ProcessArticleTests(TestCase):
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         # Create a long text that will be chunked (over 4000 chars to force chunking)
@@ -835,9 +822,8 @@ class ProcessArticleTests(TestCase):
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
         mock_tts_response.usage = MagicMock(total_tokens=100)
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         expected_empty_summary = ""
@@ -941,9 +927,8 @@ class ProcessArticleTests(TestCase):
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         with patch(
@@ -979,9 +964,8 @@ class ProcessArticleTests(TestCase):
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         mock_cas_for_vpgen = MockVPGenCAS.return_value
@@ -1050,9 +1034,8 @@ class ProcessArticleTests(TestCase):
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_create = mock_openai_instance.audio.speech.create
         mock_tts_response = MagicMock()
-        mock_tts_response.stream_to_file.side_effect = (
-            self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
         mock_speech_create.return_value = mock_tts_response
 
         mock_analysis_instance = MockCAS.return_value
@@ -1137,9 +1120,8 @@ class ProcessArticleTests(TestCase):
         # Mock OpenAI TTS client
         mock_openai_instance = MockOpenAIClient.return_value
         mock_speech_response = MagicMock()
-        mock_speech_response.stream_to_file = MagicMock(
-            side_effect=self.create_dummy_file_side_effect
-        )
+        # TTS service now uses iter_bytes() instead of stream_to_file()
+        mock_speech_response.iter_bytes.return_value = [b"dummy audio data"]
         # Ensure 'usage' attribute is present if your code accesses it, even if just for tokens
         mock_speech_response.usage = MagicMock(
             prompt_tokens=10, completion_tokens=20, total_tokens=30
@@ -1197,9 +1179,8 @@ class ProcessArticleTests(TestCase):
                 mock_openai_instance = MockOpenAIClient.return_value
                 mock_speech_create = mock_openai_instance.audio.speech.create
                 mock_tts_response = MagicMock()
-                mock_tts_response.stream_to_file.side_effect = (
-                    self.create_dummy_file_side_effect
-                )
+                # TTS service now uses iter_bytes() instead of stream_to_file()
+                mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
                 mock_speech_create.return_value = mock_tts_response
                 with patch("text_to_audio.tasks._save_openai_usage_stats"):
                     process_article(self.article.id)
@@ -1240,9 +1221,8 @@ class ProcessArticleTests(TestCase):
             mock_openai_instance = MockOpenAIClient.return_value
             mock_speech_create = mock_openai_instance.audio.speech.create
             mock_tts_response = MagicMock()
-            mock_tts_response.stream_to_file.side_effect = (
-                self.create_dummy_file_side_effect
-            )
+            # TTS service now uses iter_bytes() instead of stream_to_file()
+            mock_tts_response.iter_bytes.return_value = [b"dummy audio data"]
             mock_speech_create.return_value = mock_tts_response
             with patch("text_to_audio.tasks._save_openai_usage_stats"):
                 process_article(self.article.id)

--- a/tests/text_to_audio/test_utils.py
+++ b/tests/text_to_audio/test_utils.py
@@ -115,7 +115,8 @@ class UrlUtilsTests(TestCase):
         self.assertTrue(success)
         self.assertEqual(text, "Extracted text")
         self.assertIsNone(error)
-        mock_fetch.assert_called_once_with("https://example.com")
+        # fetch_url_content is called with max_retries parameter
+        mock_fetch.assert_called_once_with("https://example.com", max_retries=1)
         mock_extract.assert_called_once_with("html content")
 
     @patch("text_to_audio.utils.fetch_url_content")
@@ -131,7 +132,8 @@ class UrlUtilsTests(TestCase):
         self.assertFalse(success)
         self.assertEqual(text, "")
         self.assertEqual(error, "Fetch error")
-        mock_fetch.assert_called_once_with("https://example.com")
+        # fetch_url_content is called with max_retries parameter
+        mock_fetch.assert_called_once_with("https://example.com", max_retries=1)
 
 
 class SanitizeTextForTTSTests(TestCase):

--- a/tests/text_to_audio/test_views_followed_feed.py
+++ b/tests/text_to_audio/test_views_followed_feed.py
@@ -274,8 +274,12 @@ class FollowedFeedUITests(TestCase):
 
     def test_create_followed_feed_no_destination_feeds_get(self):
         """Test GET create view when user has no destination feeds."""
-        # Login as a user with no feeds
-        User.objects.create_user(username="nofeedsuser_get", password="password")
+        # Login as a user with no feeds (must be approved to access views)
+        no_feeds_user = User.objects.create_user(
+            username="nofeedsuser_get", password="password"
+        )
+        no_feeds_user.profile.is_approved = True
+        no_feeds_user.profile.save()
         self.client.login(username="nofeedsuser_get", password="password")
 
         response = self.client.get(reverse("followedfeed-create"))
@@ -290,6 +294,9 @@ class FollowedFeedUITests(TestCase):
         no_feeds_user = User.objects.create_user(
             username="nofeedsuser_post", password="password"
         )
+        # Approve user so they can access views
+        no_feeds_user.profile.is_approved = True
+        no_feeds_user.profile.save()
         self.client.login(username="nofeedsuser_post", password="password")
 
         data = {

--- a/text_to_audio/views.py
+++ b/text_to_audio/views.py
@@ -6,15 +6,12 @@ submission, listing, media serving, and article deletion.
 
 import logging
 import os
-import tempfile
 import uuid
 
-import openai
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.contrib.auth.models import User
 from django.http import (
     FileResponse,
     HttpResponseBadRequest,


### PR DESCRIPTION
### **User description**
- Update Google TTS Provider tests to patch at correct module level
  (appconfig.utils instead of text_to_audio.services.google_tts_provider)
- Update mock assertions for iter_bytes() instead of stream_to_file()
  (TTSService now uses iter_bytes() for reading audio response)
- Fix model display voice name tests to expect "(OpenAI)" suffix
- Update voice choice tests to use subset check instead of exact equality
  (accounts for new Google TTS voices being added)
- Skip permission handling tests when running as root
- Update URL utils tests to include max_retries parameter
- Fix followed feed view tests by approving test users
- Change firecrawl tests to use TestCase (requires database access)
- Remove unused imports from views.py (tempfile, openai, User)

Tests status: 562 passed, 27 skipped, 18 failed
Linting: All checks passed

Remaining failures are due to test isolation issues in ProcessArticleTests
where mocks from earlier tests affect subsequent tests.


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Update TTS tests for iter_bytes usage

- Relax voice choice assertions to subsets

- Patch Google TTS at appconfig utils

- Skip permission tests when running as root


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Tests["Tests suite updates"] -- "OpenAI TTS" --> IterBytes["Use iter_bytes() in mocks"]
  Tests -- "Google TTS" --> GooglePatch["Patch appconfig.utils + init paths"]
  Tests -- "Voices" --> SubsetChecks["Subset checks for OpenAI voices"]
  Tests -- "Permissions" --> RootSkips["Skip when running as root"]
  Tests -- "Utils" --> MaxRetries["Expect max_retries in fetch_url_content"]
  Views["Views cleanup"] -- "Remove unused imports" --> MinorCleanup["Minor refactor"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>test_canonical_media_paths.py</strong><dd><code>Skip permission test when running as root</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-f6212a78a6f0c19f09a38213db24ef86da67979cd5addcdb9b693039a8d0549e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_migrate_audio_paths.py</strong><dd><code>Skip permission error test for root user</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-dfb050b65a031434acaa266b2fb8ce2b8f52382405289caef510fa29b693b7fa">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_models.py</strong><dd><code>Update display voice names with OpenAI suffix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-0adb667cd397bd56edce10eec11e1b10821740a10d72bd148b09645fc9108968">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_verse_voice_removal.py</strong><dd><code>Use subset checks for OpenAI voices presence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-a585d144286a3d4e309650062800d82c985fa1815d4df07dfe8f1f39690e87db">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_voice_presets.py</strong><dd><code>Validate OpenAI voices via subset, not equality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-0b2939d510f18c3135f4b4894a951e343aa1401099ecbf05865ac30ff386eb43">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_firecrawl.py</strong><dd><code>Use TestCase and assert max_retries in fetch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-b7c6d8b65f1e3c6a902eb55efa9fde28f1c2e4015b4f9665d211f649892f2072">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_google_tts_provider.py</strong><dd><code>Rework Google TTS tests to patch appconfig and client libs</code></dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-5d314199c283c9af750ec72b5a55551d9e1fa09c496603e9320c4a8ef230fdc7">+183/-253</a></td>

</tr>

<tr>
  <td><strong>test_speed_control_chunk_tone.py</strong><dd><code>Switch OpenAI TTS mocks to iter_bytes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-9ba734f0abe52aad20acc9ecf6239efce5d192e127bf0aea5463c4ae430023fb">+6/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tasks.py</strong><dd><code>Replace stream_to_file with iter_bytes across task tests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-92b9935e180b5c885c30de11967e5900573cb0a2eef0b8581615d4224a58d18a">+44/-64</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_utils.py</strong><dd><code>Expect fetch_url_content called with max_retries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-1fe39273d5035edcf32c2950527048472a80fe22257f42ca227da1e382b11908">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_views_followed_feed.py</strong><dd><code>Approve users in tests to access views</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-2668e84d4cbea49fb84b86b6d26538a6f2bcb940ad487625eb035c3852702449">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>views.py</strong><dd><code>Remove unused imports from views</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/165/files#diff-9550890abb2c0f1498b48b7097fec6807b4b48079d3824e59eaf7d73759966c7">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

