### PR TITLE
Fix failing type tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,6 +7,8 @@ mypy>=1.5.1
 django-stubs>=4.2.3
 djangorestframework-stubs>=3.14.2
 types-redis>=4.6.0
+types-requests>=2.31.0
+types-PyYAML>=6.0.0
 # No official type stubs for celery, see setup.cfg for mypy config
 
 feedparser>=6.0,<7.0


### PR DESCRIPTION
### **User description**
Add types-requests and types-PyYAML to requirements-test.txt to fix mypy import-untyped errors for requests and yaml modules.


___

### **PR Type**
- Tests
- Enhancement



___

### **Description**
- Add typing stubs for requests

- Add typing stubs for PyYAML

- Improve mypy coverage in tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  reqs["requirements-test.txt"] -- "add stubs" --> mypy["mypy type checking"]
  mypy -- "resolves import-untyped errors" --> typing["requests & yaml typings"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements-test.txt</strong><dd><code>Include requests and PyYAML type stubs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements-test.txt

<ul><li>Add <code>types-requests>=2.31.0</code> to test requirements.<br> <li> Add <code>types-PyYAML>=6.0.0</code> to test requirements.<br> <li> Enhances mypy by providing missing third-party stubs.</ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/166/files#diff-685da804fbcac569d75387e475e57d1de687a54c6c41b3aa4057694cfb5abc4b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

