### PR TITLE
Allow underscores in hostnames for Docker container networking

### DIFF
--- a/rss_tts/settings.py
+++ b/rss_tts/settings.py
@@ -1,11 +1,20 @@
 """Django settings for rss_tts project."""
 
 import os
+import re
 from pathlib import Path
 
 import dj_database_url
+from django.http import request as django_request
 
 from text_to_audio.services.logging_setup import configure_logging
+
+# AIDEV-NOTE: Patch Django's host validation regex to allow underscores in hostnames.
+# This is needed for Docker internal networking where container names like 'caddy_internal'
+# contain underscores, violating RFC 952/1123 but required for container-to-container communication.
+django_request.host_validation_re = re.compile(
+    r"^([a-z0-9._-]+|\[[a-f0-9:]+\])(:[0-9]+)?$", re.IGNORECASE
+)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -59,7 +68,9 @@ ENABLE_EMAIL_CONTENT_CLEANING = os.environ.get(
     "ENABLE_EMAIL_CONTENT_CLEANING", "true"
 ).lower() in ("true", "1", "yes")
 
-ALLOWED_HOSTS: list[str] = []
+# AIDEV-NOTE: caddy_internal is always allowed for Docker internal health checks/proxying
+# The underscore in the hostname violates RFC but is common in Docker container naming
+ALLOWED_HOSTS: list[str] = ["caddy_internal"]
 ALLOWED_HOSTS += (
     os.environ.get("DJANGO_ALLOWED_HOSTS", "").split(",")
     if os.environ.get("DJANGO_ALLOWED_HOSTS")

--- a/tests/test_settings_env.py
+++ b/tests/test_settings_env.py
@@ -83,3 +83,27 @@ class TestSettingsEnvironment(unittest.TestCase):
         os.environ["DJANGO_SECRET_KEY"] = "test"
         settings = self._import_settings()
         self.assertFalse(settings.USE_FIRECRAWL_BY_DEFAULT)
+
+    def test_caddy_internal_in_allowed_hosts_by_default(self):
+        """caddy_internal should be in ALLOWED_HOSTS by default for Docker networking."""
+        os.environ["DJANGO_SECRET_KEY"] = "test"
+        settings = self._import_settings()
+        self.assertIn("caddy_internal", settings.ALLOWED_HOSTS)
+
+    def test_host_validation_allows_underscores(self):
+        """Host validation regex should allow underscores for Docker container names."""
+        os.environ["DJANGO_SECRET_KEY"] = "test"
+        self._import_settings()
+        from django.http import request as django_request
+
+        # Test that underscored hostnames pass validation
+        self.assertTrue(django_request.host_validation_re.match("caddy_internal"))
+        self.assertTrue(django_request.host_validation_re.match("my_container_name"))
+        self.assertTrue(django_request.host_validation_re.match("service_1:8000"))
+        # Standard hostnames should still work
+        self.assertTrue(django_request.host_validation_re.match("localhost"))
+        self.assertTrue(django_request.host_validation_re.match("example.com"))
+        self.assertTrue(django_request.host_validation_re.match("localhost:8000"))
+        # IPv6 should still work
+        self.assertTrue(django_request.host_validation_re.match("[::1]"))
+        self.assertTrue(django_request.host_validation_re.match("[::1]:8000"))


### PR DESCRIPTION
### **User description**
## Summary
This PR updates Django's host validation to allow underscores in hostnames, enabling proper support for Docker internal networking where container names like `caddy_internal` are used for inter-container communication.

## Key Changes
- **Host validation regex patch**: Modified Django's `host_validation_re` to accept underscores in hostnames, which violates RFC 952/1123 but is necessary for Docker container-to-container communication
- **Default ALLOWED_HOSTS**: Added `caddy_internal` to the default `ALLOWED_HOSTS` list to support Docker internal health checks and proxying
- **Test coverage**: Added comprehensive tests to verify:
  - `caddy_internal` is included in `ALLOWED_HOSTS` by default
  - Host validation regex correctly accepts underscored hostnames
  - Standard hostnames, IPv6 addresses, and port specifications continue to work

## Implementation Details
The host validation regex was updated from Django's default to: `^([a-z0-9._-]+|\[[a-f0-9:]+\])(:[0-9]+)?$`

This change:
- Adds underscores (`_`) to the allowed character set for hostnames
- Maintains backward compatibility with standard hostnames, IPv6 addresses, and port numbers
- Is scoped to the application settings and documented with inline comments explaining the Docker networking requirement

https://claude.ai/code/session_01EbmPdzeuGzwLAGZEpEJBdm


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Patch Django host_validation_re to allow underscores  

- Include `caddy_internal` in default ALLOWED_HOSTS  

- Monkey-patch settings imports for regex customization  

- Add tests validating underscore hostnames and caddy_internal


___

### Diagram Walkthrough


```mermaid
flowchart LR
  settings["rss_tts/settings.py changes"]
  regex["Updated host_validation_re regex"]
  hosts["Default ALLOWED_HOSTS includes caddy_internal"]
  tests["tests/test_settings_env.py additions"]
  settings -- "patch regex" --> regex
  settings -- "set default hosts" --> hosts
  tests -- "verify regex & hosts" --> regex
  tests -- "verify regex & hosts" --> hosts
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Patch host_validation regex and default hosts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rss_tts/settings.py

<ul><li>Imported <code>re</code> and <code>django_request</code> modules  <br> <li> Monkey-patched <code>host_validation_re</code> to permit underscores  <br> <li> Initialized <code>ALLOWED_HOSTS</code> with <code>"caddy_internal"</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/167/files#diff-1bb75f77966bdf6684a367651feda07d0610123a385f6cc06ce5152b6dc9fd8f">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_settings_env.py</strong><dd><code>Add tests for underscore hostnames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_settings_env.py

<ul><li>Added test for <code>caddy_internal</code> in <code>ALLOWED_HOSTS</code>  <br> <li> Added test for underscore hostname regex acceptance  <br> <li> Confirmed standard hostnames and IPv6 still match</ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/167/files#diff-9f4c38ff0c2b1487e787e16f0c2f9c4db4f7eae20c89cfd3b38656da28b36570">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

