### PR TITLE
Fix WAV validation to check WAVE marker, not just RIFF

### DIFF
--- a/tests/text_to_audio/test_gemini_tts_provider.py
+++ b/tests/text_to_audio/test_gemini_tts_provider.py
@@ -514,80 +514,80 @@ class GeminiTTSProviderTest(TestCase):
 
 
 class GeminiWrapPcmInWavTest(TestCase):
-    """Test the _wrap_pcm_in_wav and _is_valid_wav helper functions."""
+    """Test the wrap_pcm_in_wav and is_valid_wav helper functions."""
 
     def test_wrap_pcm_creates_valid_wav(self):
-        """Test that _wrap_pcm_in_wav creates valid WAV with RIFF header."""
-        from text_to_audio.services.gemini_tts_provider import _wrap_pcm_in_wav
+        """Test that wrap_pcm_in_wav creates valid WAV with RIFF header."""
+        from text_to_audio.audio_utils import wrap_pcm_in_wav
 
         pcm_data = b"\x00\x01\x02\x03" * 100
 
-        wav_bytes = _wrap_pcm_in_wav(pcm_data)
+        wav_bytes = wrap_pcm_in_wav(pcm_data)
 
         self.assertTrue(wav_bytes.startswith(b"RIFF"))
         self.assertEqual(wav_bytes[8:12], b"WAVE")
 
-    def test_is_valid_wav_returns_true_for_wav(self):
-        """Test _is_valid_wav returns True for valid WAV data."""
-        from text_to_audio.services.gemini_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_true_for_wav(self):
+        """Test is_valid_wav returns True for valid WAV data."""
+        from text_to_audio.audio_utils import is_valid_wav
 
         wav_data = b"RIFF\x00\x00\x00\x00WAVEfmt data"
 
-        self.assertTrue(_is_valid_wav(wav_data))
+        self.assertTrue(is_valid_wav(wav_data))
 
-    def test_is_valid_wav_returns_false_for_raw_pcm(self):
-        """Test _is_valid_wav returns False for raw PCM data."""
-        from text_to_audio.services.gemini_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_false_for_raw_pcm(self):
+        """Test is_valid_wav returns False for raw PCM data."""
+        from text_to_audio.audio_utils import is_valid_wav
 
         pcm_data = b"\x00\x00\x01\x00\x02\x00"
 
-        self.assertFalse(_is_valid_wav(pcm_data))
+        self.assertFalse(is_valid_wav(pcm_data))
 
-    def test_is_valid_wav_returns_false_for_empty_data(self):
-        """Test _is_valid_wav returns False for empty data."""
-        from text_to_audio.services.gemini_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_false_for_empty_data(self):
+        """Test is_valid_wav returns False for empty data."""
+        from text_to_audio.audio_utils import is_valid_wav
 
-        self.assertFalse(_is_valid_wav(b""))
-        self.assertFalse(_is_valid_wav(b"RI"))  # Too short
+        self.assertFalse(is_valid_wav(b""))
+        self.assertFalse(is_valid_wav(b"RI"))  # Too short
 
-    def test_is_valid_wav_returns_false_for_non_wav_riff(self):
-        """Test _is_valid_wav returns False for non-WAV RIFF containers (AVI, WebP)."""
-        from text_to_audio.services.gemini_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_false_for_non_wav_riff(self):
+        """Test is_valid_wav returns False for non-WAV RIFF containers (AVI, WebP)."""
+        from text_to_audio.audio_utils import is_valid_wav
 
         # AVI file header (RIFF but not WAVE)
         avi_data = b"RIFF\x00\x00\x00\x00AVI LIST"
-        self.assertFalse(_is_valid_wav(avi_data))
+        self.assertFalse(is_valid_wav(avi_data))
 
         # WebP file header (RIFF but not WAVE)
         webp_data = b"RIFF\x00\x00\x00\x00WEBPVP8 "
-        self.assertFalse(_is_valid_wav(webp_data))
+        self.assertFalse(is_valid_wav(webp_data))
 
-    def test_is_valid_wav_returns_false_for_short_riff_header(self):
-        """Test _is_valid_wav returns False when RIFF header is too short for WAVE check."""
-        from text_to_audio.services.gemini_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_false_for_short_riff_header(self):
+        """Test is_valid_wav returns False when RIFF header is too short for WAVE check."""
+        from text_to_audio.audio_utils import is_valid_wav
 
         # Has RIFF but not enough bytes to check WAVE marker
         short_riff = b"RIFF\x00\x00\x00\x00WAV"  # 11 bytes, missing last byte of WAVE
-        self.assertFalse(_is_valid_wav(short_riff))
+        self.assertFalse(is_valid_wav(short_riff))
 
     def test_wrap_pcm_handles_empty_data(self):
-        """Test _wrap_pcm_in_wav handles empty PCM data gracefully."""
-        from text_to_audio.services.gemini_tts_provider import _wrap_pcm_in_wav
+        """Test wrap_pcm_in_wav handles empty PCM data gracefully."""
+        from text_to_audio.audio_utils import wrap_pcm_in_wav
 
         # Should not raise an exception, but return a valid (empty) WAV
-        wav_bytes = _wrap_pcm_in_wav(b"")
+        wav_bytes = wrap_pcm_in_wav(b"")
 
         # Should still have valid WAV header
         self.assertTrue(wav_bytes.startswith(b"RIFF"))
         self.assertEqual(wav_bytes[8:12], b"WAVE")
 
     def test_wrap_pcm_handles_tiny_data(self):
-        """Test _wrap_pcm_in_wav handles very small PCM data."""
-        from text_to_audio.services.gemini_tts_provider import _wrap_pcm_in_wav
+        """Test wrap_pcm_in_wav handles very small PCM data."""
+        from text_to_audio.audio_utils import wrap_pcm_in_wav
 
         # Single sample (2 bytes for 16-bit audio)
         tiny_data = b"\x00\x00"
-        wav_bytes = _wrap_pcm_in_wav(tiny_data)
+        wav_bytes = wrap_pcm_in_wav(tiny_data)
 
         self.assertTrue(wav_bytes.startswith(b"RIFF"))
         self.assertEqual(wav_bytes[8:12], b"WAVE")

--- a/tests/text_to_audio/test_google_tts_provider.py
+++ b/tests/text_to_audio/test_google_tts_provider.py
@@ -358,16 +358,16 @@ class GoogleTTSProviderTest(TestCase):
 
 
 class WrapPcmInWavTest(TestCase):
-    """Test the _wrap_pcm_in_wav helper function."""
+    """Test the wrap_pcm_in_wav helper function."""
 
     def test_wrap_pcm_creates_valid_wav(self):
-        """Test that _wrap_pcm_in_wav creates valid WAV with RIFF header."""
-        from text_to_audio.services.google_tts_provider import _wrap_pcm_in_wav
+        """Test that wrap_pcm_in_wav creates valid WAV with RIFF header."""
+        from text_to_audio.audio_utils import wrap_pcm_in_wav
 
         # Create some fake PCM data (16-bit samples)
         pcm_data = b"\x00\x01\x02\x03" * 100
 
-        wav_bytes = _wrap_pcm_in_wav(pcm_data)
+        wav_bytes = wrap_pcm_in_wav(pcm_data)
 
         # Verify RIFF header
         self.assertTrue(wav_bytes.startswith(b"RIFF"))
@@ -376,13 +376,13 @@ class WrapPcmInWavTest(TestCase):
 
     def test_wrap_pcm_with_custom_sample_rate(self):
         """Test WAV wrapping with custom sample rate."""
-        from text_to_audio.services.google_tts_provider import _wrap_pcm_in_wav
+        from text_to_audio.audio_utils import wrap_pcm_in_wav
         import wave
         import io
 
         pcm_data = b"\x00\x00" * 48000  # 1 second at 48kHz
 
-        wav_bytes = _wrap_pcm_in_wav(pcm_data, sample_rate=48000)
+        wav_bytes = wrap_pcm_in_wav(pcm_data, sample_rate=48000)
 
         # Parse the WAV to verify sample rate
         with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
@@ -390,13 +390,13 @@ class WrapPcmInWavTest(TestCase):
 
     def test_wrap_pcm_default_sample_rate(self):
         """Test WAV wrapping uses 24000 Hz sample rate by default (Google TTS)."""
-        from text_to_audio.services.google_tts_provider import _wrap_pcm_in_wav
+        from text_to_audio.audio_utils import wrap_pcm_in_wav
         import wave
         import io
 
         pcm_data = b"\x00\x00" * 24000  # 1 second at 24kHz
 
-        wav_bytes = _wrap_pcm_in_wav(pcm_data)
+        wav_bytes = wrap_pcm_in_wav(pcm_data)
 
         # Parse the WAV to verify default sample rate
         with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
@@ -406,74 +406,74 @@ class WrapPcmInWavTest(TestCase):
 
 
 class IsValidWavTest(TestCase):
-    """Test the _is_valid_wav helper function."""
+    """Test the is_valid_wav helper function."""
 
-    def test_is_valid_wav_returns_true_for_wav(self):
-        """Test _is_valid_wav returns True for valid WAV data."""
-        from text_to_audio.services.google_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_true_for_wav(self):
+        """Test is_valid_wav returns True for valid WAV data."""
+        from text_to_audio.audio_utils import is_valid_wav
 
         wav_data = b"RIFF\x00\x00\x00\x00WAVEfmt data"
 
-        self.assertTrue(_is_valid_wav(wav_data))
+        self.assertTrue(is_valid_wav(wav_data))
 
-    def test_is_valid_wav_returns_false_for_raw_pcm(self):
-        """Test _is_valid_wav returns False for raw PCM data."""
-        from text_to_audio.services.google_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_false_for_raw_pcm(self):
+        """Test is_valid_wav returns False for raw PCM data."""
+        from text_to_audio.audio_utils import is_valid_wav
 
         pcm_data = b"\x00\x00\x01\x00\x02\x00"
 
-        self.assertFalse(_is_valid_wav(pcm_data))
+        self.assertFalse(is_valid_wav(pcm_data))
 
-    def test_is_valid_wav_returns_false_for_empty_data(self):
-        """Test _is_valid_wav returns False for empty or short data."""
-        from text_to_audio.services.google_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_false_for_empty_data(self):
+        """Test is_valid_wav returns False for empty or short data."""
+        from text_to_audio.audio_utils import is_valid_wav
 
-        self.assertFalse(_is_valid_wav(b""))
-        self.assertFalse(_is_valid_wav(b"RI"))  # Too short
-        self.assertFalse(_is_valid_wav(b"RIF"))  # Too short
+        self.assertFalse(is_valid_wav(b""))
+        self.assertFalse(is_valid_wav(b"RI"))  # Too short
+        self.assertFalse(is_valid_wav(b"RIF"))  # Too short
 
-    def test_is_valid_wav_returns_false_for_non_wav_riff(self):
-        """Test _is_valid_wav returns False for non-WAV RIFF containers (AVI, WebP)."""
-        from text_to_audio.services.google_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_false_for_non_wav_riff(self):
+        """Test is_valid_wav returns False for non-WAV RIFF containers (AVI, WebP)."""
+        from text_to_audio.audio_utils import is_valid_wav
 
         # AVI file header (RIFF but not WAVE)
         avi_data = b"RIFF\x00\x00\x00\x00AVI LIST"
-        self.assertFalse(_is_valid_wav(avi_data))
+        self.assertFalse(is_valid_wav(avi_data))
 
         # WebP file header (RIFF but not WAVE)
         webp_data = b"RIFF\x00\x00\x00\x00WEBPVP8 "
-        self.assertFalse(_is_valid_wav(webp_data))
+        self.assertFalse(is_valid_wav(webp_data))
 
-    def test_is_valid_wav_returns_false_for_short_riff_header(self):
-        """Test _is_valid_wav returns False when RIFF header is too short for WAVE check."""
-        from text_to_audio.services.google_tts_provider import _is_valid_wav
+    def testis_valid_wav_returns_false_for_short_riff_header(self):
+        """Test is_valid_wav returns False when RIFF header is too short for WAVE check."""
+        from text_to_audio.audio_utils import is_valid_wav
 
         # Has RIFF but not enough bytes to check WAVE marker
         short_riff = b"RIFF\x00\x00\x00\x00WAV"  # 11 bytes, missing last byte of WAVE
-        self.assertFalse(_is_valid_wav(short_riff))
+        self.assertFalse(is_valid_wav(short_riff))
 
 
 class WrapPcmEdgeCasesTest(TestCase):
-    """Test edge cases for _wrap_pcm_in_wav helper function."""
+    """Test edge cases for wrap_pcm_in_wav helper function."""
 
     def test_wrap_pcm_handles_empty_data(self):
-        """Test _wrap_pcm_in_wav handles empty PCM data gracefully."""
-        from text_to_audio.services.google_tts_provider import _wrap_pcm_in_wav
+        """Test wrap_pcm_in_wav handles empty PCM data gracefully."""
+        from text_to_audio.audio_utils import wrap_pcm_in_wav
 
         # Should not raise an exception, but return a valid (empty) WAV
-        wav_bytes = _wrap_pcm_in_wav(b"")
+        wav_bytes = wrap_pcm_in_wav(b"")
 
         # Should still have valid WAV header
         self.assertTrue(wav_bytes.startswith(b"RIFF"))
         self.assertEqual(wav_bytes[8:12], b"WAVE")
 
     def test_wrap_pcm_handles_tiny_data(self):
-        """Test _wrap_pcm_in_wav handles very small PCM data."""
-        from text_to_audio.services.google_tts_provider import _wrap_pcm_in_wav
+        """Test wrap_pcm_in_wav handles very small PCM data."""
+        from text_to_audio.audio_utils import wrap_pcm_in_wav
 
         # Single sample (2 bytes for 16-bit audio)
         tiny_data = b"\x00\x00"
-        wav_bytes = _wrap_pcm_in_wav(tiny_data)
+        wav_bytes = wrap_pcm_in_wav(tiny_data)
 
         self.assertTrue(wav_bytes.startswith(b"RIFF"))
         self.assertEqual(wav_bytes[8:12], b"WAVE")

--- a/text_to_audio/audio_utils.py
+++ b/text_to_audio/audio_utils.py
@@ -1,0 +1,75 @@
+"""Audio utility functions for WAV file handling.
+
+This module provides utilities for WAV file validation and PCM audio wrapping.
+"""
+
+import io
+import logging
+import wave
+
+logger = logging.getLogger(__name__)
+
+# AIDEV-NOTE: Minimum WAV header size: RIFF (4) + size (4) + WAVE (4) = 12 bytes
+MIN_WAV_HEADER_SIZE = 12
+
+
+def wrap_pcm_in_wav(
+    pcm_data: bytes, sample_rate: int = 24000, channels: int = 1, sample_width: int = 2
+) -> bytes:
+    """Wrap raw PCM data in a WAV container with proper RIFF header.
+
+    IMPORTANT: The sample_rate parameter MUST match the actual sample rate of the
+    PCM data. Using an incorrect sample rate will result in audio playing at the
+    wrong speed/pitch. Google/Gemini TTS typically uses 24000 Hz.
+
+    Args:
+        pcm_data: Raw PCM audio bytes (LINEAR16 format). Can be empty.
+        sample_rate: Sample rate in Hz. Must match the actual PCM data rate.
+            Defaults to 24000 Hz (Google/Gemini TTS default).
+        channels: Number of audio channels (1 for mono)
+        sample_width: Bytes per sample (2 for 16-bit audio)
+
+    Returns:
+        WAV file bytes with proper RIFF header
+
+    Raises:
+        ValueError: If WAV container creation fails
+    """
+    # AIDEV-NOTE: LINEAR16 from Google TTS is 24kHz mono 16-bit signed little-endian
+    try:
+        wav_buffer = io.BytesIO()
+
+        with wave.open(wav_buffer, "wb") as wav_file:
+            wav_file.setnchannels(channels)
+            wav_file.setsampwidth(sample_width)
+            wav_file.setframerate(sample_rate)
+            wav_file.writeframes(pcm_data)
+
+        return wav_buffer.getvalue()
+    except (wave.Error, OSError, IOError) as e:
+        # Catch wave.Error for WAV-specific issues and OSError/IOError for I/O problems
+        raise ValueError(f"Failed to create WAV container: {e}") from e
+
+
+def is_valid_wav(data: bytes) -> bool:
+    """Check if data has a valid WAV/RIFF header.
+
+    A valid WAV file must have:
+    - Bytes 0-3: "RIFF" (RIFF container marker)
+    - Bytes 8-11: "WAVE" (format identifier)
+
+    This distinguishes WAV files from other RIFF containers like AVI or WebP.
+
+    Args:
+        data: Audio bytes to check
+
+    Returns:
+        True if data is a valid WAV file (has both RIFF and WAVE markers)
+    """
+    # AIDEV-NOTE: Must check both RIFF (bytes 0-3) AND WAVE (bytes 8-11) markers
+    # to distinguish WAV from other RIFF containers (AVI, WebP, etc.)
+    return (
+        len(data) >= MIN_WAV_HEADER_SIZE
+        and data[:4] == b"RIFF"
+        and data[8:12] == b"WAVE"
+    )

--- a/text_to_audio/services/gemini_tts_provider.py
+++ b/text_to_audio/services/gemini_tts_provider.py
@@ -15,68 +15,12 @@ Different from GoogleTTSProvider which uses Cloud TTS API:
 """
 
 import base64
-import io
 import logging
-import wave
 from typing import Dict, Optional
 
+from text_to_audio.audio_utils import is_valid_wav, wrap_pcm_in_wav
+
 logger = logging.getLogger(__name__)
-
-
-def _wrap_pcm_in_wav(
-    pcm_data: bytes, sample_rate: int = 24000, channels: int = 1, sample_width: int = 2
-) -> bytes:
-    """Wrap raw PCM data in a WAV container with proper RIFF header.
-
-    IMPORTANT: The sample_rate parameter MUST match the actual sample rate of the
-    PCM data. Using an incorrect sample rate will result in audio playing at the
-    wrong speed/pitch. Gemini TTS typically uses 24000 Hz.
-
-    Args:
-        pcm_data: Raw PCM audio bytes (LINEAR16 format). Can be empty.
-        sample_rate: Sample rate in Hz. Must match the actual PCM data rate.
-            Gemini TTS uses 24000 Hz by default.
-        channels: Number of audio channels (1 for mono)
-        sample_width: Bytes per sample (2 for 16-bit audio)
-
-    Returns:
-        WAV file bytes with proper RIFF header
-
-    Raises:
-        ValueError: If WAV container creation fails
-    """
-    try:
-        wav_buffer = io.BytesIO()
-
-        with wave.open(wav_buffer, "wb") as wav_file:
-            wav_file.setnchannels(channels)
-            wav_file.setsampwidth(sample_width)
-            wav_file.setframerate(sample_rate)
-            wav_file.writeframes(pcm_data)
-
-        return wav_buffer.getvalue()
-    except wave.Error as e:
-        raise ValueError(f"Failed to create WAV container: {e}") from e
-
-
-def _is_valid_wav(data: bytes) -> bool:
-    """Check if data has a valid WAV/RIFF header.
-
-    A valid WAV file must have:
-    - Bytes 0-3: "RIFF" (RIFF container marker)
-    - Bytes 8-11: "WAVE" (format identifier)
-
-    This distinguishes WAV files from other RIFF containers like AVI or WebP.
-
-    Args:
-        data: Audio bytes to check
-
-    Returns:
-        True if data is a valid WAV file (has both RIFF and WAVE markers)
-    """
-    # AIDEV-NOTE: Must check both RIFF (bytes 0-3) AND WAVE (bytes 8-11) markers
-    # to distinguish WAV from other RIFF containers (AVI, WebP, etc.)
-    return len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WAVE"
 
 
 # Available Gemini TTS models
@@ -275,11 +219,11 @@ class GeminiTTSProvider:
 
             # AIDEV-NOTE: Gemini API may return raw PCM without WAV headers
             # Validate and wrap in WAV container if needed for ffmpeg/pydub compatibility
-            if output_format.lower() == "wav" and not _is_valid_wav(audio_bytes):
+            if output_format.lower() == "wav" and not is_valid_wav(audio_bytes):
                 logger.debug(
                     "Gemini returned raw audio without RIFF header, wrapping in WAV container"
                 )
-                audio_bytes = _wrap_pcm_in_wav(audio_bytes)
+                audio_bytes = wrap_pcm_in_wav(audio_bytes)
 
             logger.info(f"Gemini TTS synthesis successful: {len(audio_bytes)} bytes")
             return audio_bytes
@@ -374,11 +318,11 @@ class GeminiTTSProvider:
                 audio_bytes = audio_data
 
             # AIDEV-NOTE: Gemini API may return raw PCM without WAV headers
-            if output_format.lower() == "wav" and not _is_valid_wav(audio_bytes):
+            if output_format.lower() == "wav" and not is_valid_wav(audio_bytes):
                 logger.debug(
                     "Gemini multi-speaker returned raw audio, wrapping in WAV container"
                 )
-                audio_bytes = _wrap_pcm_in_wav(audio_bytes)
+                audio_bytes = wrap_pcm_in_wav(audio_bytes)
 
             logger.info(
                 f"Gemini TTS multi-speaker synthesis successful: {len(audio_bytes)} bytes"

--- a/text_to_audio/services/google_tts_provider.py
+++ b/text_to_audio/services/google_tts_provider.py
@@ -12,73 +12,12 @@ control over tone, emotion, accent, pace, and speaking style through natural
 language instructions.
 """
 
-import io
 import logging
-import wave
 from typing import Dict, Optional
 
+from text_to_audio.audio_utils import is_valid_wav, wrap_pcm_in_wav
+
 logger = logging.getLogger(__name__)
-
-
-def _wrap_pcm_in_wav(
-    pcm_data: bytes, sample_rate: int = 24000, channels: int = 1, sample_width: int = 2
-) -> bytes:
-    """Wrap raw PCM data (LINEAR16) in a WAV container with proper RIFF header.
-
-    Note: Google Cloud TTS LINEAR16 encoding should include WAV headers per docs,
-    but this function is used as a safety fallback if raw PCM is encountered.
-    Gemini TTS via Cloud TTS API may return raw PCM in some cases.
-
-    IMPORTANT: The sample_rate parameter MUST match the actual sample rate of the
-    PCM data. Using an incorrect sample rate will result in audio playing at the
-    wrong speed/pitch. Google Cloud TTS typically uses 24000 Hz for LINEAR16.
-
-    Args:
-        pcm_data: Raw PCM audio bytes (LINEAR16 format). Can be empty.
-        sample_rate: Sample rate in Hz. Must match the actual PCM data rate.
-            Google TTS uses 24000 Hz by default.
-        channels: Number of audio channels (1 for mono)
-        sample_width: Bytes per sample (2 for 16-bit audio)
-
-    Returns:
-        WAV file bytes with proper RIFF header
-
-    Raises:
-        ValueError: If WAV container creation fails
-    """
-    # AIDEV-NOTE: LINEAR16 from Google TTS is 24kHz mono 16-bit signed little-endian
-    try:
-        wav_buffer = io.BytesIO()
-
-        with wave.open(wav_buffer, "wb") as wav_file:
-            wav_file.setnchannels(channels)
-            wav_file.setsampwidth(sample_width)
-            wav_file.setframerate(sample_rate)
-            wav_file.writeframes(pcm_data)
-
-        return wav_buffer.getvalue()
-    except wave.Error as e:
-        raise ValueError(f"Failed to create WAV container: {e}") from e
-
-
-def _is_valid_wav(data: bytes) -> bool:
-    """Check if data has a valid WAV/RIFF header.
-
-    A valid WAV file must have:
-    - Bytes 0-3: "RIFF" (RIFF container marker)
-    - Bytes 8-11: "WAVE" (format identifier)
-
-    This distinguishes WAV files from other RIFF containers like AVI or WebP.
-
-    Args:
-        data: Audio bytes to check
-
-    Returns:
-        True if data is a valid WAV file (has both RIFF and WAVE markers)
-    """
-    # AIDEV-NOTE: Must check both RIFF (bytes 0-3) AND WAVE (bytes 8-11) markers
-    # to distinguish WAV from other RIFF containers (AVI, WebP, etc.)
-    return len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WAVE"
 
 
 # AIDEV-NOTE: Gemini TTS models - use these for prompt/styling support
@@ -298,8 +237,8 @@ class GoogleTTSProvider:
 
             # AIDEV-NOTE: Cloud TTS LINEAR16 should include WAV headers per docs, but
             # check and wrap as fallback if raw PCM is encountered (safety measure)
-            if output_format.lower() == "wav" and not _is_valid_wav(audio_bytes):
-                audio_bytes = _wrap_pcm_in_wav(audio_bytes)
+            if output_format.lower() == "wav" and not is_valid_wav(audio_bytes):
+                audio_bytes = wrap_pcm_in_wav(audio_bytes)
                 logger.debug(
                     f"Wrapped LINEAR16 data in WAV container: {len(audio_bytes)} bytes"
                 )
@@ -396,8 +335,8 @@ class GoogleTTSProvider:
 
             # AIDEV-NOTE: Cloud TTS LINEAR16 should include WAV headers per docs, but
             # check and wrap as fallback if raw PCM is encountered (safety measure)
-            if output_format.lower() == "wav" and not _is_valid_wav(audio_bytes):
-                audio_bytes = _wrap_pcm_in_wav(audio_bytes)
+            if output_format.lower() == "wav" and not is_valid_wav(audio_bytes):
+                audio_bytes = wrap_pcm_in_wav(audio_bytes)
                 logger.debug(
                     f"Wrapped LINEAR16 data in WAV container: {len(audio_bytes)} bytes"
                 )


### PR DESCRIPTION
### **User description**
## Summary
Fixed a critical bug in WAV file validation that was incorrectly accepting non-WAV RIFF containers (AVI, WebP, etc.) as valid WAV files. The validation now properly checks for both the RIFF container marker and the WAVE format identifier.

## Key Changes

- **Fixed `_is_valid_wav()` in both providers**: Updated validation logic to check both RIFF (bytes 0-3) AND WAVE (bytes 8-11) markers instead of just checking for RIFF. This prevents false positives for other RIFF-based formats like AVI and WebP.

- **Enhanced error handling in `_wrap_pcm_in_wav()`**: Added try-catch blocks to catch `wave.Error` exceptions and re-raise as `ValueError` with descriptive messages, improving error reporting.

- **Improved documentation**: 
  - Added detailed docstrings explaining the RIFF/WAVE marker requirements
  - Added AIDEV-NOTE comments explaining why both markers must be checked
  - Clarified that `pcm_data` can be empty
  - Added warnings about sample rate parameter importance

- **Comprehensive test coverage**: Added 5 new test cases covering:
  - Non-WAV RIFF containers (AVI, WebP)
  - Short RIFF headers that lack the WAVE marker
  - Empty PCM data handling
  - Tiny PCM data handling

## Implementation Details

The validation fix changes the minimum required data length from 4 bytes to 12 bytes to safely access the WAVE marker at bytes 8-11. This prevents index out-of-bounds errors while ensuring proper format validation.

Both `gemini_tts_provider.py` and `google_tts_provider.py` were updated identically to maintain consistency across the codebase.

https://claude.ai/code/session_015v6zrvSQYADWZoC6UKEi9Z


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Add WAV container wrapping for raw PCM audio

- Implement valid WAV detection via RIFF/WAVE markers

- Integrate wrapping logic in Gemini & Google providers

- Expand tests covering wrapping and validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio bytes"] -- "check WAV validity" --> B{"_is_valid_wav?"}
  B -- "true" --> C["return audio_bytes"]
  B -- "false" --> D["_wrap_pcm_in_wav"]
  D --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gemini_tts_provider.py</strong><dd><code>Add WAV wrap & validation helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/services/gemini_tts_provider.py

<ul><li>Imported <code>io</code> and <code>wave</code> modules<br> <li> Added helper <code>_wrap_pcm_in_wav</code> to wrap PCM in WAV<br> <li> Added helper <code>_is_valid_wav</code> to validate WAV headers<br> <li> Integrated wrapping in <code>synthesize_speech</code> and <code>synthesize_multispeaker</code></ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/170/files#diff-fc22433ebde6e1d7f9cd6d28b983f146104ecf009a3bec0e95c99d5234484b2a">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>google_tts_provider.py</strong><dd><code>Implement WAV wrapping & validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/services/google_tts_provider.py

<ul><li>Imported <code>io</code> and <code>wave</code> modules<br> <li> Added helper <code>_wrap_pcm_in_wav</code> and <code>_is_valid_wav</code><br> <li> Wrapped raw PCM when <code>output_format="wav"</code><br> <li> Added debug logging on WAV wrapping</ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/170/files#diff-afd30cbbc417d5897d73646fec1fb37d554435c0a2b8f2ef6a6002cac94c9db5">+82/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gemini_tts_provider.py</strong><dd><code>Add WAV wrap & validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/text_to_audio/test_gemini_tts_provider.py

<ul><li>Defined raw PCM and WAV sample fixtures<br> <li> Added tests for <code>_wrap_pcm_in_wav</code> behavior<br> <li> Added tests for <code>_is_valid_wav</code> edge cases<br> <li> Added synthesize tests to prevent double-wrapping</ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/170/files#diff-f6196f988bd0fe1dae90deede3f28d76feaaf9af96e0798e0e32262371336757">+152/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_google_tts_provider.py</strong><dd><code>Extend tests for WAV wrapping in Google provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/text_to_audio/test_google_tts_provider.py

<ul><li>Reformatted patch context managers to tuple style<br> <li> Updated <code>test_synthesize_speech_success</code> for WAV wrapping<br> <li> Added tests for MP3 no-wrap and WAV no-rewrap<br> <li> Introduced WrapPcmInWavTest, IsValidWavTest, edge-case tests</ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/170/files#diff-5d314199c283c9af750ec72b5a55551d9e1fa09c496603e9320c4a8ef230fdc7">+201/-32</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

