### PR TITLE
Fix voice/provider mismatch in TTS fallback logic

### DIFF
--- a/appconfig/utils.py
+++ b/appconfig/utils.py
@@ -51,6 +51,30 @@ def get_openai_tts_voice() -> str:
     )
 
 
+def get_default_voice_for_provider(provider: str) -> str:
+    """Get the default voice for a given TTS provider.
+
+    Args:
+        provider: TTS provider name ("openai" or "google")
+
+    Returns:
+        str: Default voice name for the provider
+    """
+    if provider == "openai":
+        return get_openai_tts_voice()
+    elif provider == "google":
+        # Get the configured Google TTS voice type and return appropriate default
+        voice_type = get_google_tts_voice_type()
+        return {
+            "gemini": "Kore",
+            "chirp3": "en-US-Chirp3-HD-Charon",
+            "neural2": "en-US-Neural2-A",
+        }.get(voice_type, "Kore")
+    else:
+        # Unknown provider, fall back to OpenAI voice
+        return get_openai_tts_voice()
+
+
 def get_openai_tts_response_format() -> str:
     config = get_global_config()
     return (

--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -724,19 +724,31 @@ def process_article(self, article_id: int) -> str:
                 chunk_tone_service = ChunkToneService()
 
                 # Determine fallback voice for ChunkToneService
-                # Use the same logic as single-voice fallback
-                from appconfig.utils import get_openai_tts_voice
+                # AIDEV-NOTE: Use provider-aware voice selection to avoid voice/provider mismatch
+                from appconfig.utils import (
+                    get_default_tts_provider,
+                    get_default_voice_for_provider,
+                )
+
+                # Determine effective TTS provider for this article
+                effective_provider = (
+                    article.tts_provider
+                    or article.feed.tts_provider
+                    or get_default_tts_provider()
+                )
 
                 if article.voice_parameters:
                     fallback_voice = (
                         article.voice
                         or article.voice_parameters.get("voice_id")
                         or article.voice_id
-                        or get_openai_tts_voice()
+                        or get_default_voice_for_provider(effective_provider)
                     )
                 else:
                     fallback_voice = (
-                        article.voice or article.voice_id or get_openai_tts_voice()
+                        article.voice
+                        or article.voice_id
+                        or get_default_voice_for_provider(effective_provider)
                     )
 
                 # Prepare text for chunking (title removed to prevent duplication)
@@ -1251,7 +1263,18 @@ def process_article(self, article_id: int) -> str:
 
             # Use enhanced voice parameters if available (from auto-voice)
             voice_prompt = None
-            from appconfig.utils import get_openai_tts_voice
+            # AIDEV-NOTE: Use provider-aware voice selection to avoid voice/provider mismatch
+            from appconfig.utils import (
+                get_default_tts_provider,
+                get_default_voice_for_provider,
+            )
+
+            # Determine effective TTS provider for this article
+            effective_provider = (
+                article.tts_provider
+                or article.feed.tts_provider
+                or get_default_tts_provider()
+            )
 
             # AIDEV-NOTE: Voice preset prompt extraction - keep in sync with voice_preset_test view
             # Check for voice preset prompt first (highest priority when preset is used)
@@ -1268,7 +1291,7 @@ def process_article(self, article_id: int) -> str:
                     article.voice
                     or article.voice_parameters.get("voice_id")
                     or article.voice_id
-                    or get_openai_tts_voice()
+                    or get_default_voice_for_provider(effective_provider)
                 )
                 fallback_speed = (
                     article.voice_parameters.get("speed") or article.speed or 1.0
@@ -1282,7 +1305,9 @@ def process_article(self, article_id: int) -> str:
             else:
                 # Check voice field first, then voice_id, then default
                 fallback_voice = (
-                    article.voice or article.voice_id or get_openai_tts_voice()
+                    article.voice
+                    or article.voice_id
+                    or get_default_voice_for_provider(effective_provider)
                 )
                 fallback_speed = article.speed or 1.0
 
@@ -1323,7 +1348,7 @@ def process_article(self, article_id: int) -> str:
                 # Log fallback TTS API call details
                 logger.info(
                     f"Fallback TTS API Call - Article {article_id}, chunk {i}: "
-                    f"model={tts_args['model']}, voice={fallback_voice}, "
+                    f"provider={effective_provider}, voice={fallback_voice}, "
                     f"speed={fallback_speed}, text_length={len(chunk)} chars"
                     + (f", instructions='{voice_prompt}'" if voice_prompt else "")
                 )
@@ -1333,10 +1358,8 @@ def process_article(self, article_id: int) -> str:
                     # AIDEV-NOTE: TTS provider abstraction - supports OpenAI and Google
                     from .services.tts_service import TTSService
 
-                    # Initialize TTS service with article's provider
-                    tts_service = TTSService(
-                        provider=article.tts_provider or article.feed.tts_provider
-                    )
+                    # Initialize TTS service with effective provider (already determined above)
+                    tts_service = TTSService(provider=effective_provider)
 
                     # Generate speech using provider-agnostic interface
                     audio_bytes = tts_service.generate_speech(


### PR DESCRIPTION
### **User description**
## Summary
This PR fixes a critical bug where the TTS fallback voice selection was not aligned with the effective TTS provider for an article, potentially causing voice/provider mismatches during audio generation.

## Key Changes
- **New utility function**: Added `get_default_voice_for_provider()` in `appconfig/utils.py` to return provider-appropriate default voices
  - Supports OpenAI and Google TTS providers
  - Maps Google voice types (gemini, chirp3, neural2) to their corresponding default voices
  - Falls back to OpenAI voice for unknown providers

- **Updated fallback voice logic** in `text_to_audio/tasks.py`:
  - Replaced hardcoded `get_openai_tts_voice()` calls with `get_default_voice_for_provider(effective_provider)`
  - Determines effective TTS provider by checking: article → feed → global default
  - Applied consistently across both ChunkToneService and main TTS processing paths

- **Improved logging**: Changed fallback TTS log message to report `provider` instead of `model` for clarity

## Implementation Details
- The effective provider is determined once at the start of voice parameter resolution and reused throughout the article processing
- This ensures the fallback voice always matches the provider that will actually be used for TTS generation
- Maintains backward compatibility by falling back to OpenAI voice for unknown providers
- Includes AIDEV-NOTE comments explaining the provider-aware voice selection logic

https://claude.ai/code/session_01Y4AK5DBzeqHYRb6ub6uFY5


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add provider-based default voice utility

- Use provider-aware voice in TTS fallback

- Determine effective TTS provider per article

- Update logging with provider info


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Article > Feed > Global"] -- "determine provider" --> B["get_default_voice_for_provider"]
  B -- "select fallback voice" --> C["TTSService(provider)"]
  C -- "generate_speech" --> D["Audio output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Add provider-based default voice util</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

appconfig/utils.py

<ul><li>Added get_default_voice_for_provider function<br> <li> Supports 'openai', 'google', and fallback cases<br> <li> Maps Google voice types to default voices</ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/175/files#diff-3059d6e1af5db04e95a7e5bb236680627d0f23e8bf12f62a71af939cd63d476c">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tasks.py</strong><dd><code>Refactor TTS fallback for provider-aware voices</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

text_to_audio/tasks.py

<ul><li>Imported provider-aware utility functions<br> <li> Determine effective_provider from article/feed/global default<br> <li> Replace openai-only fallback with provider-specific voices<br> <li> Updated logging to report provider instead of model<br> <li> Initialize TTSService with effective provider</ul>


</details>


  </td>
  <td><a href="https://github.com/JM-Addington/RSS-TTS/pull/175/files#diff-de8add76ee05b0f2966a00749cedd86824b9d710327aa1c48d56844b35e4ee70">+35/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

