### PR TITLE
Fix TTS pauses after abbreviations

### DIFF
--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -122,6 +122,24 @@ class ChunkTextTests(TestCase):
         self.assertIn("Second sentence", chunks[1])
         self.assertIn("Third one", chunks[2])
 
+    def test_does_not_split_after_title_abbreviation(self):
+        """Keep a title abbreviation with the sentence it introduces."""
+        text = "Dr. Smith left. He waved."
+
+        success, chunks = _legacy_chunk_text(text, max_length=20)
+
+        self.assertTrue(success)
+        self.assertEqual(chunks, ["Dr. Smith left.", "He waved."])
+
+    def test_does_not_split_after_initialism_abbreviation(self):
+        """Keep an initialism abbreviation with the rest of its sentence."""
+        text = "The U.S. envoy spoke. The audience listened."
+
+        success, chunks = _legacy_chunk_text(text, max_length=25)
+
+        self.assertTrue(success)
+        self.assertEqual(chunks, ["The U.S. envoy spoke.", "The audience listened."])
+
     def test_long_word_handling(self):
         text = "Supercalifragilisticexpialidocious"
         success, chunks = _legacy_chunk_text(text, max_length=20)

--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time  # Added for timing API calls
 import traceback
 import uuid
@@ -224,7 +225,7 @@ def _legacy_chunk_text(text: str, max_length: int = 4000) -> tuple[bool, list[st
     Uses a linear scanning approach for better performance on large documents.
     Prioritizes natural breaks in this order:
     1. Line breaks (\n)
-    2. Sentence boundaries (. ! ?)
+    2. Sentence boundaries (. ! ?), excluding abbreviations
     3. Clause boundaries (; ,)
     4. Word boundaries (spaces)
     5. Force splits within words as last resort
@@ -296,7 +297,12 @@ def _legacy_chunk_text(text: str, max_length: int = 4000) -> tuple[bool, list[st
             # Line break - highest priority
             chunks.append(current_chunk.strip())
             current_chunk = ""
-        elif char in sentence_breaks and i + 1 < text_len and text[i + 1].isspace():
+        elif (
+            char in sentence_breaks
+            and i + 1 < text_len
+            and text[i + 1].isspace()
+            and not _legacy_is_abbreviation(current_chunk)
+        ):
             # Sentence break followed by space
             current_chunk += text[i + 1]  # Include the space
             chunks.append(current_chunk.strip())
@@ -331,6 +337,22 @@ def _legacy_chunk_text(text: str, max_length: int = 4000) -> tuple[bool, list[st
     chunks = [chunk for chunk in chunks if chunk]
 
     return perfect_split, chunks
+
+
+def _legacy_is_abbreviation(text: str) -> bool:
+    """Return whether text ends in an abbreviation rather than a sentence.
+
+    The chunker inserts a pause between generated audio files. Splitting after
+    an abbreviation would therefore create an unnatural pause in speech.
+    """
+    token = text.rstrip()
+    return bool(
+        re.search(
+            r"(?:\b(?:dr|mr|mrs|ms|prof|sr|jr|st|mt|vs|etc)\.|\b(?:[A-Za-z]\.){2,})$",
+            token,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _legacy_find_best_break_point(text: str, max_length: int) -> int:


### PR DESCRIPTION
### Motivation

- Audio output currently inserts an unnatural pause when chunking sentences that end with common abbreviations (e.g., "Dr.", "U.S."), causing audible breaks in the middle of sentences.

### Description

- Adjust `_legacy_chunk_text` to avoid treating periods that are part of title abbreviations or dotted initialisms as sentence boundaries when splitting for TTS chunks by adding an abbreviation check before splitting on `. ! ?`.
- Add `_legacy_is_abbreviation` helper that detects common title abbreviations and dotted initialisms using a case-insensitive regex and import `re` to support it.
- Add regression tests in `tests/text_to_audio/test_tasks.py` covering `Dr.` and `U.S.` cases to ensure those abbreviations remain attached to their sentences and that normal sentence splitting still works.

### Testing

- Ran the chunking unit tests with audio mocks using `DiscoverRunner` for `tests.text_to_audio.test_tasks.ChunkTextTests`, which executed 15 tests and all passed (`OK`).
- Ran `pre-commit` checks for the modified files with `pre-commit run --files text_to_audio/tasks.py tests/text_to_audio/test_tasks.py` and the checks passed for the staged changes.
- Note: running the full test suite earlier without audio mocks surfaced unrelated audio dependency errors in the environment; the focused chunking tests were executed with the project's test-mock helpers to validate the change and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f51c756c48326a5783f063086b8b1)