### PR TITLE
fix: abbreviation-aware TTS chunking (consolidates #237 + #238) [AI]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ mike2.txt
 # pytest cache
 .pytest_cache/
 
+# Virtual environments
+.venv/
+venv/
+
 # Log files
 logs/
 googlegemini.json

--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -294,6 +294,21 @@ class ChunkTextTests(TestCase):
         self.assertTrue(success)
         self.assertEqual(len(chunks), 3)
 
+    # Exact-boundary regression tests: the abbreviation stays attached to its
+    # own sentence AND the following real sentence still splits into its own
+    # chunk (guards against over-merging that would swallow real boundaries).
+    def test_title_abbreviation_exact_chunk_boundaries(self):
+        text = "Dr. Smith left. He waved."
+        success, chunks = _legacy_chunk_text(text, max_length=20)
+        self.assertTrue(success)
+        self.assertEqual(chunks, ["Dr. Smith left.", "He waved."])
+
+    def test_initialism_exact_chunk_boundaries(self):
+        text = "The U.S. envoy spoke. The audience listened."
+        success, chunks = _legacy_chunk_text(text, max_length=25)
+        self.assertTrue(success)
+        self.assertEqual(chunks, ["The U.S. envoy spoke.", "The audience listened."])
+
 
 @override_settings(
     MEDIA_ROOT=TEST_MEDIA_ROOT,

--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -309,6 +309,83 @@ class ChunkTextTests(TestCase):
         self.assertTrue(success)
         self.assertEqual(chunks, ["The U.S. envoy spoke.", "The audience listened."])
 
+    def test_no_as_number_prefix_not_split(self):
+        # "No. 1" is an ordinal-number abbreviation and must stay together;
+        # the real sentence break after "class." should be used instead.
+        text = "He is No. 1 in the class. Everyone agreed."
+        success, chunks = _legacy_chunk_text(text, max_length=28)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertFalse(
+                chunk.endswith("No."),
+                f"Chunk ends mid-abbreviation: {chunk!r}",
+            )
+
+    def test_no_ending_sentence_still_splits(self):
+        # "no." here ends a real sentence, so the boundary must be respected.
+        text = "I said no. He agreed with me completely."
+        success, chunks = _legacy_chunk_text(text, max_length=20)
+        self.assertTrue(success)
+        self.assertIn("I said no.", chunks)
+        self.assertTrue(
+            any(chunk.endswith("no.") for chunk in chunks),
+            f"Expected a chunk ending with 'no.': {chunks!r}",
+        )
+
+    def test_plural_title_not_split(self):
+        # Plural prefix-only titles ("Sens.", "Drs.") always precede a name and
+        # must never be treated as a sentence boundary.
+        text = "Sens. Smith and Jones introduced it. Drs. Lee and Poe agreed."
+        success, chunks = _legacy_chunk_text(text, max_length=35)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertFalse(
+                chunk.endswith(("Sens.", "Drs.")),
+                f"Chunk ends mid-abbreviation: {chunk!r}",
+            )
+
+    def test_reps_ending_sentence_still_splits(self):
+        # "reps." is the common fitness word, NOT a title abbreviation; the
+        # sentence boundary must be respected (guards against blanket-adding it).
+        text = "He did ten reps. Then he rested for a while."
+        success, chunks = _legacy_chunk_text(text, max_length=20)
+        self.assertTrue(success)
+        self.assertIn("He did ten reps.", chunks)
+        self.assertTrue(
+            any(chunk.endswith("reps.") for chunk in chunks),
+            f"Expected a chunk ending with 'reps.': {chunks!r}",
+        )
+
+    def test_profs_ending_sentence_still_splits(self):
+        # "profs." is an informal standalone word, NOT a title abbreviation;
+        # the sentence boundary must be respected (guards against adding it).
+        text = "Students praised their profs. Leaders approved the plan."
+        success, chunks = _legacy_chunk_text(text, max_length=30)
+        self.assertTrue(success)
+        self.assertTrue(
+            any(chunk.endswith("profs.") for chunk in chunks),
+            f"Expected a chunk ending with 'profs.': {chunks!r}",
+        )
+
+    def test_word_boundary_orphan_preserves_characters(self):
+        # Super-edge: on the forced-overflow word-boundary fallback an
+        # abbreviation may be orphaned from its following token ("Dr." | "Name").
+        # That is an accepted tradeoff, but it must NEVER corrupt characters
+        # WITHIN a chunk (no "Dr.Name" gluing). The boundary space simply becomes
+        # the inter-chunk pause. This characterizes/guards that invariant.
+        text = "He met Dr. Montgomery."
+        success, chunks = _legacy_chunk_text(text, max_length=20)
+        # No chunk may contain an abbreviation glued to the next word.
+        for chunk in chunks:
+            self.assertNotRegex(
+                chunk,
+                r"\b(?:Dr|Mr|Mrs|Ms|No)\.\S",
+                f"Abbreviation glued to next token inside a chunk: {chunk!r}",
+            )
+        # Characters are preserved modulo the single boundary space that becomes
+        # the pause: joining chunks with a space reconstructs the input.
+        self.assertEqual(" ".join(chunks), text)
+
 
 @override_settings(
     MEDIA_ROOT=TEST_MEDIA_ROOT,

--- a/tests/text_to_audio/test_tasks.py
+++ b/tests/text_to_audio/test_tasks.py
@@ -213,6 +213,87 @@ class ChunkTextTests(TestCase):
                 total_chunk_chars = sum(len(chunk) for chunk in chunks)
                 self.assertGreaterEqual(total_chunk_chars, len(text) * 0.9)
 
+    # AIDEV-NOTE: Chunk boundaries become 400ms audio pauses (SEGMENT_PAUSE_MS),
+    # so abbreviations like "Dr." / "U.S." must never end a chunk.
+    def test_no_split_after_title_abbreviations(self):
+        text = (
+            "Yesterday Dr. Smith met with Mr. Jones and Mrs. Lee to talk. "
+            "They spoke for hours about the plan and its details."
+        )
+        success, chunks = _legacy_chunk_text(text, max_length=60)
+        self.assertTrue(success)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertFalse(
+                chunk.endswith(("Dr.", "Mr.", "Mrs.")),
+                f"Chunk ends mid-abbreviation: {chunk!r}",
+            )
+
+    def test_no_split_after_dotted_acronyms(self):
+        text = (
+            "The U.S. economy grew this year. Analysts say growth will "
+            "continue into next year across most regions of the U.S. market."
+        )
+        success, chunks = _legacy_chunk_text(text, max_length=60)
+        self.assertTrue(success)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertFalse(
+                chunk.endswith("U.S."),
+                f"Chunk ends mid-acronym: {chunk!r}",
+            )
+
+    def test_no_split_after_single_letter_initials(self):
+        text = (
+            "Author J. K. Rowling wrote many books. The books sold well "
+            "around the world for many years after their release."
+        )
+        success, chunks = _legacy_chunk_text(text, max_length=60)
+        self.assertTrue(success)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertFalse(
+                chunk.endswith(("J.", "K.")),
+                f"Chunk ends mid-initials: {chunk!r}",
+            )
+
+    def test_no_split_after_latin_abbreviations(self):
+        text = (
+            "Some fruits, e.g. apples and pears, are cheap right now. "
+            "Other fruits are far more expensive in the winter months."
+        )
+        success, chunks = _legacy_chunk_text(text, max_length=60)
+        self.assertTrue(success)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertFalse(
+                chunk.endswith("e.g."),
+                f"Chunk ends mid-abbreviation: {chunk!r}",
+            )
+
+    def test_break_point_search_skips_abbreviations(self):
+        # No real sentence break exists, so the backward break-point search
+        # must not pick the period in "Dr." and should fall back to a
+        # word-boundary split instead.
+        text = (
+            "He met Dr. Brown yesterday afternoon and they talked for a "
+            "long time without stopping once during the entire meeting"
+        )
+        success, chunks = _legacy_chunk_text(text, max_length=40)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertLessEqual(len(chunk), 40)
+            self.assertFalse(
+                chunk.endswith("Dr."),
+                f"Chunk ends mid-abbreviation: {chunk!r}",
+            )
+
+    def test_real_sentence_breaks_still_split(self):
+        text = "First sentence here. Second sentence there. Third one now."
+        success, chunks = _legacy_chunk_text(text, max_length=30)
+        self.assertTrue(success)
+        self.assertEqual(len(chunks), 3)
+
 
 @override_settings(
     MEDIA_ROOT=TEST_MEDIA_ROOT,

--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time  # Added for timing API calls
 import traceback
 import uuid
@@ -218,6 +219,122 @@ def _save_openai_usage_stats(
         )
 
 
+# AIDEV-NOTE: Chunk boundaries become 400ms audio pauses (SEGMENT_PAUSE_MS), so a
+# period that is part of an abbreviation must never be treated as a sentence end.
+# Common abbreviations whose trailing period does not end a sentence.
+_NON_SENTENCE_ABBREVIATIONS = frozenset(
+    {
+        # Titles and honorifics
+        "mr",
+        "mrs",
+        "ms",
+        "dr",
+        "prof",
+        "rev",
+        "hon",
+        "fr",
+        "st",
+        "gen",
+        "sen",
+        "rep",
+        "gov",
+        "pres",
+        "sec",
+        "amb",
+        "lt",
+        "col",
+        "sgt",
+        "capt",
+        "cmdr",
+        "maj",
+        "cpl",
+        "pvt",
+        "adm",
+        "jr",
+        "sr",
+        # Common textual abbreviations
+        "vs",
+        "etc",
+        "approx",
+        "appt",
+        "apt",
+        "dept",
+        "est",
+        "fig",
+        "inc",
+        "ltd",
+        "co",
+        "corp",
+        "no",
+        "nos",
+        "vol",
+        "vols",
+        "al",
+        "ave",
+        "blvd",
+        "rd",
+        "mt",
+        "ft",
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "jun",
+        "jul",
+        "aug",
+        "sep",
+        "sept",
+        "oct",
+        "nov",
+        "dec",
+    }
+)
+
+# Dotted acronyms and initialisms such as "U.S.", "U.K.", "e.g.", "i.e.", "a.m.".
+_DOTTED_ACRONYM_RE = re.compile(r"(?:[A-Za-z]\.){2,}$")
+
+
+def _period_ends_sentence(text: str, i: int) -> bool:
+    """Return True if the period at ``text[i]`` ends a sentence.
+
+    A period does NOT end a sentence when it belongs to an abbreviation
+    ("Dr.", "vs."), a dotted acronym ("U.S.", "e.g."), a single-letter
+    initial ("J. Smith"), or when the next word starts with a lowercase
+    letter (which almost never happens after a real sentence boundary).
+    """
+    # Extract the whitespace-delimited word ending at (and including) the period.
+    start = i
+    while start > 0 and not text[start - 1].isspace():
+        start -= 1
+    word = text[start : i + 1]
+
+    if _DOTTED_ACRONYM_RE.search(word):
+        return False
+
+    core = word[:-1].strip("\"'()[]“”‘’")
+    if len(core) == 1 and core.isalpha():
+        return False
+    if core.lower() in _NON_SENTENCE_ABBREVIATIONS:
+        return False
+
+    # Peek at the next word: lowercase start implies the sentence continues.
+    j = i + 1
+    while j < len(text) and text[j].isspace():
+        j += 1
+    if j < len(text) and text[j].islower():
+        return False
+
+    return True
+
+
+def _is_sentence_boundary(text: str, i: int) -> bool:
+    """Return True if the break character at ``text[i]`` is a real sentence end."""
+    char = text[i]
+    if char in ("!", "?"):
+        return True
+    return _period_ends_sentence(text, i)
+
+
 def _legacy_chunk_text(text: str, max_length: int = 4000) -> tuple[bool, list[str]]:
     """Split text into chunks for TTS processing (optimized for large texts).
 
@@ -296,8 +413,14 @@ def _legacy_chunk_text(text: str, max_length: int = 4000) -> tuple[bool, list[st
             # Line break - highest priority
             chunks.append(current_chunk.strip())
             current_chunk = ""
-        elif char in sentence_breaks and i + 1 < text_len and text[i + 1].isspace():
-            # Sentence break followed by space
+        elif (
+            char in sentence_breaks
+            and i + 1 < text_len
+            and text[i + 1].isspace()
+            and _is_sentence_boundary(text, i)
+        ):
+            # Sentence break followed by space (abbreviations like "Dr." and
+            # "U.S." are not sentence breaks — see _period_ends_sentence)
             current_chunk += text[i + 1]  # Include the space
             chunks.append(current_chunk.strip())
             current_chunk = ""
@@ -344,9 +467,14 @@ def _legacy_find_best_break_point(text: str, max_length: int) -> int:
     # Search backwards from max_length for break opportunities
     search_text = text[:max_length]
 
-    # Priority 1: Sentence breaks with space after
+    # Priority 1: Sentence breaks with space after (skipping abbreviations
+    # like "Dr." and "U.S.", which would otherwise become audio pauses)
     for i in range(len(search_text) - 2, -1, -1):
-        if search_text[i] in {".", "!", "?"} and search_text[i + 1].isspace():
+        if (
+            search_text[i] in {".", "!", "?"}
+            and search_text[i + 1].isspace()
+            and _is_sentence_boundary(search_text, i)
+        ):
             return i + 2  # Include the punctuation and space
 
     # Priority 2: Clause breaks with space after

--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -252,6 +252,15 @@ _NON_SENTENCE_ABBREVIATIONS = frozenset(
         "adm",
         "jr",
         "sr",
+        # Plural title forms that are prefix-only (always precede a name, never
+        # end a sentence). AIDEV-NOTE: only add plurals that are NOT common
+        # standalone English words. "sens"/"drs"/"messrs" are safe; "reps"
+        # (fitness), "revs" (engine), "cos", and "profs" (informal plural of
+        # professor) collide with real words and would recreate the "no."
+        # false-positive bug, so they are excluded.
+        "sens",
+        "drs",
+        "messrs",
         # Common textual abbreviations
         "vs",
         "etc",
@@ -265,7 +274,9 @@ _NON_SENTENCE_ABBREVIATIONS = frozenset(
         "ltd",
         "co",
         "corp",
-        "no",
+        # AIDEV-NOTE: "no" is NOT a blanket abbreviation; "no." commonly ends real
+        # sentences. Handled as an ordinal-number prefix ("No. 1") in
+        # _period_ends_sentence instead. Keep "nos" (plural, rare as a word).
         "nos",
         "vol",
         "vols",
@@ -294,6 +305,22 @@ _NON_SENTENCE_ABBREVIATIONS = frozenset(
 _DOTTED_ACRONYM_RE = re.compile(r"(?:[A-Za-z]\.){2,}$")
 
 
+# AIDEV-NOTE: Heuristic splitter that deliberately ERRS TOWARD NOT SPLITTING.
+# Accepted tradeoffs (missed pause, not a wrong pause): a sentence ending in a
+# dotted acronym ("...banned in the U.S. Canada permits it.") or followed by a
+# lowercase-initial brand ("...yesterday. iPhone users...") gets no inter-sentence
+# pause. Splitting those would reintroduce audible pauses inside phrases like
+# "the U.S. economy", which is worse. Do NOT "fix" without weighing that regression.
+# Also accepted: an abbreviation/ordinal ("No. 1", "Dr. Smith") can be split away
+# from its following token, but ONLY on the forced-overflow path — when a span
+# longer than max_length contains no sentence-ending period and no clause comma/
+# semicolon, so _legacy_find_best_break_point falls through to the word-boundary
+# fallback and the rightmost space happens to follow an abbreviation. In real
+# article prose (commas/periods every few words) this is ~never reached at
+# max_length=4000; the split is clean (boundary space becomes the pause, no
+# within-chunk char corruption). Special seam-rewriting to prevent it risks
+# dropping the token's internal space (e.g. "No.1"), a worse defect, so it is
+# left as a super-edge tradeoff.
 def _period_ends_sentence(text: str, i: int) -> bool:
     """Return True if the period at ``text[i]`` ends a sentence.
 
@@ -312,15 +339,24 @@ def _period_ends_sentence(text: str, i: int) -> bool:
         return False
 
     core = word[:-1].strip("\"'()[]“”‘’")
+    core_lower = core.lower()
     if len(core) == 1 and core.isalpha():
         return False
-    if core.lower() in _NON_SENTENCE_ABBREVIATIONS:
+    if core_lower in _NON_SENTENCE_ABBREVIATIONS:
         return False
 
-    # Peek at the next word: lowercase start implies the sentence continues.
+    # Peek at the next non-space character.
     j = i + 1
     while j < len(text) and text[j].isspace():
         j += 1
+
+    # AIDEV-NOTE: "No." is an abbreviation for "number" only when followed by a
+    # digit ("No. 1", "No. 5"); otherwise "no." ends a real sentence and must
+    # remain a boundary (e.g. "The answer is no. He agreed.").
+    if core_lower == "no" and j < len(text) and text[j].isdigit():
+        return False
+
+    # Lowercase start implies the sentence continues.
     if j < len(text) and text[j].islower():
         return False
 

--- a/text_to_audio/tasks.py
+++ b/text_to_audio/tasks.py
@@ -307,10 +307,14 @@ _DOTTED_ACRONYM_RE = re.compile(r"(?:[A-Za-z]\.){2,}$")
 
 # AIDEV-NOTE: Heuristic splitter that deliberately ERRS TOWARD NOT SPLITTING.
 # Accepted tradeoffs (missed pause, not a wrong pause): a sentence ending in a
-# dotted acronym ("...banned in the U.S. Canada permits it.") or followed by a
-# lowercase-initial brand ("...yesterday. iPhone users...") gets no inter-sentence
-# pause. Splitting those would reintroduce audible pauses inside phrases like
-# "the U.S. economy", which is worse. Do NOT "fix" without weighing that regression.
+# dotted acronym ("...banned in the U.S. Canada permits it."), a terminal-capable
+# abbreviation ("...led by Acme Inc. Shares rose."; also "etc.", "Corp.", "Ltd."),
+# or followed by a lowercase-initial brand ("...yesterday. iPhone users...") gets
+# no inter-sentence pause. Splitting those would reintroduce audible pauses inside
+# phrases like "the U.S. economy" or "Lakers vs. Celtics", which is worse — a
+# capitalized next word does NOT disambiguate (titles like "Dr. Smith" and "vs.
+# Celtics" also precede capitals). Do NOT "fix" without weighing that regression;
+# tracked as an enhancement, not a bug (missed pauses only, never corrupted audio).
 # Also accepted: an abbreviation/ordinal ("No. 1", "Dr. Smith") can be split away
 # from its following token, but ONLY on the forced-overflow path — when a span
 # longer than max_length contains no sentence-ending period and no clause comma/
@@ -504,12 +508,18 @@ def _legacy_find_best_break_point(text: str, max_length: int) -> int:
     search_text = text[:max_length]
 
     # Priority 1: Sentence breaks with space after (skipping abbreviations
-    # like "Dr." and "U.S.", which would otherwise become audio pauses)
+    # like "Dr." and "U.S.", which would otherwise become audio pauses).
+    # AIDEV-NOTE: pass the FULL `text` (not truncated `search_text`) so the
+    # boundary check's forward peek can see past the max_length slice — e.g. a
+    # "No. 1" ordinal straddling the boundary in the tail `remaining` path needs
+    # the digit "1" that lies just beyond search_text. `search_text` is a prefix
+    # of `text`, so index `i` refers to the same char in both; this is inert on
+    # the main overflow path (there current_chunk == search_text).
     for i in range(len(search_text) - 2, -1, -1):
         if (
             search_text[i] in {".", "!", "?"}
             and search_text[i + 1].isspace()
-            and _is_sentence_boundary(search_text, i)
+            and _is_sentence_boundary(text, i)
         ):
             return i + 2  # Include the punctuation and space
 


### PR DESCRIPTION
## Summary

Consolidates the two competing PRs — **#237** (Claude Fable) and **#238** (Codex) — that both fix audible TTS pauses after abbreviations, and hardens the result through an iterative coder → reviewer → codex-xhigh review loop. Supersedes both.

**The bug:** text chunking ended a chunk at every period-space, and audio assembly inserts 400ms of silence (`SEGMENT_PAUSE_MS`) at each chunk boundary — producing unnatural pauses after "Dr.", "U.S.", "e.g.", single-letter initials, etc.

## Why this combination

**Base: #237's implementation** — strictly more complete than #238:
- Fixes **both** code paths: the sequential scanner (`_legacy_chunk_text`) **and** the backward break-point search (`_legacy_find_best_break_point`). #238 only patched the scanner, so a long span with no natural sentence break would still pause at an abbreviation.
- Handles dotted acronyms (`U.S.`, `e.g.`), single-letter initials (`J. K. Rowling`), a broad abbreviation set, and a lowercase-next-word heuristic via `_period_ends_sentence` / `_is_sentence_boundary`.

**Folded in from #238:** its stronger exact-chunk-boundary regression tests.

## Hardening from the review loop

| Reviewer | Finding | Resolution |
|---|---|---|
| gemini | `"no"` in the abbreviation set breaks chunking for the common word "no." ("The answer is no. He agreed.") | Removed from the set; only `No. <digit>` ordinals are non-boundaries |
| codex xhigh | `"profs"` collides with informal "profs." | Removed; kept only safe plural titles `sens`/`drs`/`messrs`, excluded collision-prone `reps`/`revs`/`cos` |
| codex xhigh | An earlier seam-lookahead attempt dropped an abbreviation's internal space (`"No. "` → `"No.1"`) | Reverted the fragile seam logic; accepted the rare boundary split as a documented tradeoff |

**Accepted super-edge tradeoffs (documented in AIDEV-NOTEs):** a sentence ending in a dotted acronym or followed by a lowercase-initial brand ("iPhone") gets no inter-sentence pause (missed pause, never a wrong one); an abbreviation can be orphaned only on the rare `>max_length` overflow path with zero sentence/clause punctuation (near-impossible at the production `max_length=4000`, and always a clean split with no within-chunk corruption — guarded by a characterization test).

## Changes
- `text_to_audio/tasks.py`: abbreviation-aware sentence-boundary detection applied to both chunking paths.
- `tests/text_to_audio/test_tasks.py`: 14 regression/characterization tests.
- `.gitignore`: ignore local virtualenv dirs.

## Testing
- Full suite in Docker: **778 passed, 27 skipped**.
- `ChunkTextTests`: 27 passed.
- pre-commit incl. pre-push (black, isort, flake8): all pass.

## Review process
Independent reviewers layered per the project owner's directive: gemini (automated), a teammate code reviewer, and codex xhigh as the strict final gate. Focus was kept on production-impacting defects; codex xhigh twice caught issues the teammate reviewer missed (including genuine character corruption hidden by a whitespace-blind check), which is why the layered gate was retained. Remaining items are documented super-edge cases / nitpicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)